### PR TITLE
v0.0.5-alpha

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -1,9 +1,5 @@
 package schemax
 
-import (
-	"fmt"
-)
-
 type collection []interface{}
 
 /*
@@ -357,15 +353,15 @@ func (c *collection) append(x interface{}) error {
 		*DITStructureRule:
 		// ok
 	default:
-		return fmt.Errorf("Unsupported type (%T) for collection append", tv)
+		return raise(unexpectedType, "Unsupported type (%T) for collection append", tv)
 	}
 
 	// If there is at least one element, make sure we
 	// only appending new elements of the same type.
 	if c.len() > 0 {
 		first := c.index(0)
-		if fmt.Sprintf("%T", first) != fmt.Sprintf("%T", x) {
-			return fmt.Errorf("Unsupported type mixture: cannot append %T to %T-based collection", x, first)
+		if sprintf("%T", first) != sprintf("%T", x) {
+			return raise(unexpectedType, "Unsupported type mixture: cannot append %T to %T-based collection", x, first)
 		}
 	}
 

--- a/dcr.go
+++ b/dcr.go
@@ -1,9 +1,6 @@
 package schemax
 
-import (
-	"fmt"
-	"sync"
-)
+import "sync"
 
 /*
 DITContentRuleCollection describes all DITContentRules-based types.
@@ -198,7 +195,7 @@ Set is a thread-safe append method that returns an error instance indicative of 
 */
 func (r *DITContentRules) Set(x *DITContentRule) error {
 	if _, exists := r.Contains(x.OID); exists {
-		return fmt.Errorf("%T already contains %T:%s", r, x, x.OID)
+		return nil //silent
 	}
 
 	r.mutex.Lock()
@@ -344,6 +341,89 @@ func (r *DITContentRule) unmarshal() (string, error) {
 		return r.ufn()
 	}
 	return r.unmarshalBasic()
+}
+
+/*
+Map is a convenience method that returns a map[string][]string instance containing the effective contents of the receiver.
+*/
+func (r *DITContentRule) Map() (def map[string][]string) {
+	if err := r.Validate(); err != nil {
+		return
+	}
+
+	def = make(map[string][]string, 14)
+	def[`OID`] = []string{r.OID.String()}
+
+	if !r.Name.IsZero() {
+		def[`NAME`] = make([]string, 0)
+		for i := 0; i < r.Name.Len(); i++ {
+			def[`NAME`] = append(def[`NAME`], r.Name.Index(i))
+		}
+	}
+
+	if len(r.Description) > 0 {
+		def[`DESC`] = []string{r.Description.String()}
+	}
+
+	if !r.Aux.IsZero() {
+		def[`AUX`] = make([]string, 0)
+		for i := 0; i < r.Aux.Len(); i++ {
+			aux := r.Aux.Index(i)
+			term := aux.Name.Index(0)
+			if len(term) == 0 {
+				term = aux.OID.String()
+			}
+			def[`AUX`] = append(def[`AUX`], term)
+		}
+	}
+
+	if !r.Must.IsZero() {
+		def[`MUST`] = make([]string, 0)
+		for i := 0; i < r.Must.Len(); i++ {
+			must := r.Must.Index(i)
+			term := must.Name.Index(0)
+			if len(term) == 0 {
+				term = must.OID.String()
+			}
+			def[`MUST`] = append(def[`MUST`], term)
+		}
+	}
+
+	if !r.May.IsZero() {
+		def[`MAY`] = make([]string, 0)
+		for i := 0; i < r.May.Len(); i++ {
+			must := r.May.Index(i)
+			term := must.Name.Index(0)
+			if len(term) == 0 {
+				term = must.OID.String()
+			}
+			def[`MAY`] = append(def[`MAY`], term)
+		}
+	}
+
+	if !r.Not.IsZero() {
+		def[`NOT`] = make([]string, 0)
+		for i := 0; i < r.Not.Len(); i++ {
+			not := r.Not.Index(i)
+			term := not.Name.Index(0)
+			if len(term) == 0 {
+				term = not.OID.String()
+			}
+			def[`NOT`] = append(def[`NOT`], term)
+		}
+	}
+
+	if !r.Extensions.IsZero() {
+		for k, v := range r.Extensions {
+			def[k] = v
+		}
+	}
+
+	if r.Obsolete() {
+		def[`OBSOLETE`] = []string{`TRUE`}
+	}
+
+	return def
 }
 
 /*

--- a/def.go
+++ b/def.go
@@ -877,6 +877,16 @@ func (def *definition) alreadySet(idx int) (isSet bool) {
 
 type Name collection
 
+/*
+Len returns an integer indicative of the number of NAME values present within the receiver.
+*/
+func (r Name) Len() int {
+	return len(r)
+}
+
+/*
+Equal returns a boolean indicative of whether the value(s) provided match the receiver.
+*/
 func (r Name) Equal(x interface{}) bool {
 	//return collection(r).equal(collection(n))
 	if r.IsZero() {

--- a/doc_test.go
+++ b/doc_test.go
@@ -210,7 +210,6 @@ func ExampleSubschema_MarshalNameForm() {
 	sch.MRC = PopulateDefaultMatchingRules()
 	sch.ATC = PopulateDefaultAttributeTypes()
 	sch.OCC = PopulateDefaultObjectClasses()
-	sch.NFC = NewNameForms()
 
 	myDef := `( 1.3.6.1.4.1.56521.999.104.17.2.16.4
                 NAME 'jesseNameForm'
@@ -273,7 +272,6 @@ func ExampleSubschema_MarshalDITContentRule() {
 	sch.MRC = PopulateDefaultMatchingRules()
 	sch.ATC = PopulateDefaultAttributeTypes()
 	sch.OCC = PopulateDefaultObjectClasses()
-	sch.DCRC = NewDITContentRules()
 
 	dcr := `( 0.9.2342.19200300.100.4.5
                 NAME 'accountContentRule'
@@ -529,7 +527,7 @@ func ExampleUnmarshal() {
 	}
 
 	fmt.Printf("%s\n", def)
-	// Output: ( 2.5.4.41 NAME 'name' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch X-ORIGIN 'RFC4519' )
+	// Output: ( 2.5.4.41 NAME 'name' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC4519' )
 }
 
 func ExampleAttributeTypes_Get() {
@@ -1256,6 +1254,186 @@ func ExampleProhibitedAttributeTypes_Label() {
 	lab := not.Label()
 	fmt.Printf("%T label: %s (len:%d)\n", not, lab, len(lab))
 	// Output: schemax.ProhibitedAttributeTypes label: NOT (len:3)
+}
+
+func ExampleAttributeType_SingleValue() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+	sch.MRC = PopulateDefaultMatchingRules()
+	sch.ATC = NewAttributeTypes()
+
+	myDef := `( 1.3.6.1.4.1.56521.999.104.17.2.1.10
+                        NAME ( 'jessesNewAttr' 'jesseAltName' )
+                        DESC 'This is an example AttributeType definition'
+                        SINGLE-VALUE SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+                        EQUALITY caseIgnoreMatch X-ORIGIN 'Jesse Coretta' )`
+
+	if err := sch.MarshalAttributeType(myDef); err != nil {
+		panic(err)
+	}
+
+	jattr := sch.ATC.Get(`jessesNewAttr`)
+	fmt.Printf("%T is single-value: %t\n", jattr, jattr.SingleValue())
+	// Output: *schemax.AttributeType is single-value: true
+}
+
+func ExampleLDAPSyntax_Map() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+
+	syn := sch.LSC.Get(`1.3.6.1.4.1.1466.115.121.1.15`).Map()
+	fmt.Printf("%T fields: %d\n", syn, len(syn))
+	// Output: map[string][]string fields: 3
+}
+
+func ExampleDITContentRule_Map() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+	sch.MRC = PopulateDefaultMatchingRules()
+	sch.ATC = PopulateDefaultAttributeTypes()
+	sch.OCC = PopulateDefaultObjectClasses()
+
+	myDef := `( 2.16.840.1.113730.3.2.2
+			NAME 'inetOrgPerson-content-rule'
+			AUX strongAuthenticationUser
+			MUST uid
+			MAY c
+			NOT telexNumber )`
+
+	if err := sch.MarshalDITContentRule(myDef); err != nil {
+		panic(err)
+	}
+
+	dcr := sch.DCRC.Get(`2.16.840.1.113730.3.2.2`).Map()
+	fmt.Printf("%T fields: %d\n", dcr, len(dcr))
+	// Output: map[string][]string fields: 6
+}
+
+func ExampleMatchingRuleUse_Map() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+	sch.MRC = PopulateDefaultMatchingRules()
+	sch.ATC = PopulateDefaultAttributeTypes()
+	sch.MRUC.Refresh(sch.ATC)
+
+	mru := sch.MRUC.Get(`2.5.13.1`).Map()
+	fmt.Printf("%T fields: %d\n", mru, len(mru))
+	// Output: map[string][]string fields: 3
+}
+
+func ExampleMatchingRule_Map() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+	sch.MRC = PopulateDefaultMatchingRules()
+
+	mr := sch.MRC.Get(`2.5.13.1`).Map()
+	fmt.Printf("%T fields: %d\n", mr, len(mr))
+	// Output: map[string][]string fields: 4
+}
+
+func ExampleAttributeType_Map() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+	sch.MRC = PopulateDefaultMatchingRules()
+	sch.ATC = NewAttributeTypes()
+
+	myDef := `( 1.3.6.1.4.1.56521.999.104.17.2.1.10
+                        NAME ( 'jessesNewAttr' 'jesseAltName' )
+                        DESC 'This is an example AttributeType definition'
+                        SINGLE-VALUE SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+                        EQUALITY caseIgnoreMatch X-ORIGIN 'Jesse Coretta' )`
+
+	if err := sch.MarshalAttributeType(myDef); err != nil {
+		panic(err)
+	}
+
+	jattr := sch.ATC.Get(`jessesNewAttr`).Map()
+	fmt.Printf("%T fields: %d\n", jattr, len(jattr))
+	// Output: map[string][]string fields: 7
+}
+
+func ExampleObjectClass_Map() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+	sch.MRC = PopulateDefaultMatchingRules()
+	sch.ATC = PopulateDefaultAttributeTypes()
+	sch.OCC = PopulateDefaultObjectClasses()
+
+	myDef := `( 1.3.6.1.4.1.56521.999.104.17.3.71.3
+                        NAME 'jessesClass'
+                        DESC 'This is an example ObjectClass definition'
+			SUP top
+			AUXILIARY
+			MUST ( cn $ l $ o )
+			MAY ( description $ c )
+                        X-ORIGIN 'Jesse Coretta' )`
+
+	if err := sch.MarshalObjectClass(myDef); err != nil {
+		panic(err)
+	}
+
+	jclass := sch.OCC.Get(`jessesClass`).Map()
+	fmt.Printf("%T fields: %d\n", jclass, len(jclass))
+	// Output: map[string][]string fields: 8
+}
+
+func ExampleNameForm_Map() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+	sch.MRC = PopulateDefaultMatchingRules()
+	sch.ATC = PopulateDefaultAttributeTypes()
+	sch.OCC = PopulateDefaultObjectClasses()
+	sch.NFC = NewNameForms()
+
+	myDef := `( 1.3.6.1.4.1.56521.999.104.17.2.16.4
+                NAME 'jesseNameForm'
+                DESC 'this is an example Name Form definition'
+                OC account
+                MUST ( cn $ o $ uid )
+                MAY ( description $ l )
+                X-ORIGIN 'Jesse Coretta' )`
+
+	if err := sch.MarshalNameForm(myDef); err != nil {
+		panic(err)
+	}
+
+	jnf := sch.NFC.Get(`jesseNameForm`).Map()
+	fmt.Printf("%T fields: %d\n", jnf, len(jnf))
+	// Output: map[string][]string fields: 7
+}
+
+func ExampleDITStructureRule_Map() {
+	sch := NewSubschema()
+	sch.LSC = PopulateDefaultLDAPSyntaxes()
+	sch.MRC = PopulateDefaultMatchingRules()
+	sch.ATC = PopulateDefaultAttributeTypes()
+	sch.OCC = PopulateDefaultObjectClasses()
+
+	nf := `( 1.3.6.1.4.1.56521.999.104.17.2.16.4
+                NAME 'jesseNameForm'
+                DESC 'this is an example Name Form definition'
+                OC account
+                MUST ( cn $ o $ uid )
+                MAY ( description $ l )
+                X-ORIGIN 'Jesse Coretta' )`
+
+	if err := sch.MarshalNameForm(nf); err != nil {
+		panic(err)
+	}
+
+	dsr := `( 0
+                NAME 'jesseDSR'
+                DESC 'this is an example DIT Structure Rule'
+                FORM jesseNameForm
+                X-ORIGIN 'Jesse Coretta' )`
+
+	if err := sch.MarshalDITStructureRule(dsr); err != nil {
+		panic(err)
+	}
+
+	jdsr := sch.DSRC.Get(`jesseDSR`).Map()
+	fmt.Printf("%T fields: %d\n", jdsr, len(jdsr))
+	// Output: map[string][]string fields: 5
 }
 
 func ExampleUsage_Label() {

--- a/ls.go
+++ b/ls.go
@@ -1,9 +1,6 @@
 package schemax
 
-import (
-	"fmt"
-	"sync"
-)
+import "sync"
 
 /*
 LDAPSyntaxTypeCollection describes all LDAPSyntax-based types.
@@ -163,7 +160,7 @@ Set is a thread-safe append method that returns an error instance indicative of 
 */
 func (r *LDAPSyntaxes) Set(x *LDAPSyntax) error {
 	if _, exists := r.Contains(x.OID); exists {
-		return fmt.Errorf("%T already contains %T:%s", r, x, x.OID)
+		return nil
 	}
 
 	r.mutex.Lock()
@@ -312,6 +309,34 @@ func (r *LDAPSyntax) LDAPSyntaxUnmarshalFunc() (def string, err error) {
 	def += WHSP + tail
 
 	return
+}
+
+/*
+Map is a convenience method that returns a map[string][]string instance containing the effective contents of the receiver.
+*/
+func (r *LDAPSyntax) Map() (def map[string][]string) {
+	if err := r.Validate(); err != nil {
+		return
+	}
+
+	def = make(map[string][]string, 14)
+	def[`OID`] = []string{r.OID.String()}
+
+	if len(r.Description) > 0 {
+		def[`DESC`] = []string{r.Description.String()}
+	}
+
+	if !r.Extensions.IsZero() {
+		for k, v := range r.Extensions {
+			def[k] = v
+		}
+	}
+
+	if r.Obsolete() {
+		def[`OBSOLETE`] = []string{`TRUE`}
+	}
+
+	return def
 }
 
 func (r *LDAPSyntax) unmarshalBasic() (def string, err error) {


### PR DESCRIPTION
## v0.0.5-alpha

- Map (`map[string][]string`) unmarshal support for all definition types
- Fixed issue with missing flags in text unmarshal for `*AttributeType`