### PR TITLE
v0.0.6-alpha

### DIFF
--- a/at.go
+++ b/at.go
@@ -88,6 +88,13 @@ type AttributeType struct {
 }
 
 /*
+Type returns the formal name of the receiver in order to satisfy signature requirements of the Definition interface type.
+*/
+func (r *AttributeType) Type() string {
+	return `AttributeType`
+}
+
+/*
 String is an unsafe convenience wrapper for Unmarshal(r). If an error is encountered, an empty string definition is returned. If reliability and error handling are important, use Unmarshal.
 */
 func (r *AttributeType) String() (def string) {
@@ -655,6 +662,7 @@ func (r *AttributeType) Map() (def map[string][]string) {
 	}
 
 	def = make(map[string][]string, 14)
+	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
 	if !r.Name.IsZero() {
@@ -674,10 +682,10 @@ func (r *AttributeType) Map() (def map[string][]string) {
 
 	if !r.Syntax.IsZero() {
 		syn := r.Syntax.OID.String()
-		if r.MaxLength() > 0 {
-			syn += `{` + itoa(r.MaxLength()) + `}`
-		}
 		def[`SYNTAX`] = []string{syn}
+		if r.MaxLength() > 0 {
+			def[`MUB`] = []string{itoa(r.MaxLength())}
+		}
 	}
 
 	if !r.Equality.IsZero() {
@@ -738,11 +746,11 @@ func (r *AttributeType) Map() (def map[string][]string) {
 }
 
 /*
-AttributeTypeUnmarshalFunction is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *AttributeType) AttributeTypeUnmarshalFunc() (def string, err error) {
+func (r *AttributeType) UnmarshalFunc() (def string, err error) {
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/at.go
+++ b/at.go
@@ -664,6 +664,7 @@ func (r *AttributeType) Map() (def map[string][]string) {
 	def = make(map[string][]string, 14)
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
+	def[`TYPE`] = []string{r.Type()}
 
 	if len(r.info) > 0 {
 		def[`INFO`] = []string{string(r.info)}

--- a/at.go
+++ b/at.go
@@ -673,7 +673,11 @@ func (r *AttributeType) Map() (def map[string][]string) {
 	}
 
 	if !r.Syntax.IsZero() {
-		def[`SYNTAX`] = []string{r.Syntax.OID.String()}
+		syn := r.Syntax.OID.String()
+		if r.MaxLength() > 0 {
+			syn += `{` + itoa(r.MaxLength()) + `}`
+		}
+		def[`SYNTAX`] = []string{syn}
 	}
 
 	if !r.Equality.IsZero() {

--- a/at.go
+++ b/at.go
@@ -665,6 +665,10 @@ func (r *AttributeType) Map() (def map[string][]string) {
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
+	if len(r.info) > 0 {
+		def[`INFO`] = []string{string(r.info)}
+	}
+
 	if !r.Name.IsZero() {
 		def[`NAME`] = make([]string, 0)
 		for i := 0; i < r.Name.Len(); i++ {

--- a/dcr.go
+++ b/dcr.go
@@ -74,6 +74,13 @@ type DITContentRules struct {
 }
 
 /*
+Type returns the formal name of the receiver in order to satisfy signature requirements of the Definition interface type.
+*/
+func (r *DITContentRule) Type() string {
+	return `DITContentRule`
+}
+
+/*
 Equal performs a deep-equal between the receiver and the provided collection type.
 */
 func (r DITContentRules) Equal(x DITContentRuleCollection) bool {
@@ -352,6 +359,7 @@ func (r *DITContentRule) Map() (def map[string][]string) {
 	}
 
 	def = make(map[string][]string, 14)
+	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
 	if !r.Name.IsZero() {
@@ -427,11 +435,11 @@ func (r *DITContentRule) Map() (def map[string][]string) {
 }
 
 /*
-DITContentRuleUnmarshalFunction is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *DITContentRule) DITContentRuleUnmarshalFunc() (def string, err error) {
+func (r *DITContentRule) UnmarshalFunc() (def string, err error) {
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/dcr.go
+++ b/dcr.go
@@ -361,6 +361,7 @@ func (r *DITContentRule) Map() (def map[string][]string) {
 	def = make(map[string][]string, 14)
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
+	def[`TYPE`] = []string{r.Type()}
 
 	if len(r.info) > 0 {
 		def[`INFO`] = []string{string(r.info)}

--- a/dcr.go
+++ b/dcr.go
@@ -362,6 +362,10 @@ func (r *DITContentRule) Map() (def map[string][]string) {
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
+	if len(r.info) > 0 {
+		def[`INFO`] = []string{string(r.info)}
+	}
+
 	if !r.Name.IsZero() {
 		def[`NAME`] = make([]string, 0)
 		for i := 0; i < r.Name.Len(); i++ {

--- a/def.go
+++ b/def.go
@@ -64,10 +64,27 @@ type Definition interface {
 	// within the receiver.
 	Info() []byte
 
+	// Map returns a map[string][]string instance containing the receiver's
+	// components. A nil map is returned if validation checks fail.
+	Map() map[string][]string
+
+	// Type returns the formal name of the type of definition expressed by
+	// the receiver. The given value will be one of: AttributeType, NameForm,
+	// ObjectClass, DITContentRule, DITStructureRule, LDAPSyntax, MatchingRule
+	// or MatchingRuleUse.
+	Type() string
+
 	// SetUnmarshalFunc assigns the provided DefinitionUnmarshalFunc signature
 	// value to the receiver. The provided function shall be executed during the
 	// unmarshal or unsafe stringification process.
 	SetUnmarshalFunc(DefinitionUnmarshalFunc)
+
+	// UnmarshalFunc is a package-included function that honors the signature
+	// of the first class (closure) DefinitionUnmarshalFunc type. The purpose
+	// of this function, and similar user-devised ones, is to help unmarshal
+	// a definition with specific formatting included, such as linebreaks,
+	// leading specifier declarations and indenting.
+	UnmarshalFunc() (string, error)
 }
 
 /*

--- a/doc_test.go
+++ b/doc_test.go
@@ -1283,7 +1283,7 @@ func ExampleLDAPSyntax_Map() {
 
 	syn := sch.LSC.Get(`1.3.6.1.4.1.1466.115.121.1.15`).Map()
 	fmt.Printf("%T fields: %d\n", syn, len(syn))
-	// Output: map[string][]string fields: 4
+	// Output: map[string][]string fields: 5
 }
 
 func ExampleDITContentRule_Map() {
@@ -1306,7 +1306,7 @@ func ExampleDITContentRule_Map() {
 
 	dcr := sch.DCRC.Get(`2.16.840.1.113730.3.2.2`).Map()
 	fmt.Printf("%T fields: %d\n", dcr, len(dcr))
-	// Output: map[string][]string fields: 7
+	// Output: map[string][]string fields: 8
 }
 
 func ExampleMatchingRuleUse_Map() {
@@ -1318,7 +1318,7 @@ func ExampleMatchingRuleUse_Map() {
 
 	mru := sch.MRUC.Get(`2.5.13.1`).Map()
 	fmt.Printf("%T fields: %d\n", mru, len(mru))
-	// Output: map[string][]string fields: 4
+	// Output: map[string][]string fields: 5
 }
 
 func ExampleMatchingRule_Map() {
@@ -1328,7 +1328,7 @@ func ExampleMatchingRule_Map() {
 
 	mr := sch.MRC.Get(`2.5.13.1`).Map()
 	fmt.Printf("%T fields: %d\n", mr, len(mr))
-	// Output: map[string][]string fields: 5
+	// Output: map[string][]string fields: 6
 }
 
 func ExampleAttributeType_Map() {
@@ -1349,7 +1349,7 @@ func ExampleAttributeType_Map() {
 
 	jattr := sch.ATC.Get(`jessesNewAttr`).Map()
 	fmt.Printf("%T fields: %d\n", jattr, len(jattr))
-	// Output: map[string][]string fields: 9
+	// Output: map[string][]string fields: 10
 }
 
 func ExampleObjectClass_Map() {
@@ -1374,7 +1374,7 @@ func ExampleObjectClass_Map() {
 
 	jclass := sch.OCC.Get(`jessesClass`).Map()
 	fmt.Printf("%T fields: %d\n", jclass, len(jclass))
-	// Output: map[string][]string fields: 9
+	// Output: map[string][]string fields: 10
 }
 
 func ExampleNameForm_Map() {
@@ -1399,7 +1399,7 @@ func ExampleNameForm_Map() {
 
 	jnf := sch.NFC.Get(`jesseNameForm`).Map()
 	fmt.Printf("%T fields: %d\n", jnf, len(jnf))
-	// Output: map[string][]string fields: 8
+	// Output: map[string][]string fields: 9
 }
 
 func ExampleDITStructureRule_Map() {
@@ -1433,7 +1433,7 @@ func ExampleDITStructureRule_Map() {
 
 	jdsr := sch.DSRC.Get(`jesseDSR`).Map()
 	fmt.Printf("%T fields: %d\n", jdsr, len(jdsr))
-	// Output: map[string][]string fields: 6
+	// Output: map[string][]string fields: 7
 }
 
 func ExampleUsage_Label() {

--- a/doc_test.go
+++ b/doc_test.go
@@ -1283,7 +1283,7 @@ func ExampleLDAPSyntax_Map() {
 
 	syn := sch.LSC.Get(`1.3.6.1.4.1.1466.115.121.1.15`).Map()
 	fmt.Printf("%T fields: %d\n", syn, len(syn))
-	// Output: map[string][]string fields: 3
+	// Output: map[string][]string fields: 4
 }
 
 func ExampleDITContentRule_Map() {
@@ -1306,7 +1306,7 @@ func ExampleDITContentRule_Map() {
 
 	dcr := sch.DCRC.Get(`2.16.840.1.113730.3.2.2`).Map()
 	fmt.Printf("%T fields: %d\n", dcr, len(dcr))
-	// Output: map[string][]string fields: 6
+	// Output: map[string][]string fields: 7
 }
 
 func ExampleMatchingRuleUse_Map() {
@@ -1318,7 +1318,7 @@ func ExampleMatchingRuleUse_Map() {
 
 	mru := sch.MRUC.Get(`2.5.13.1`).Map()
 	fmt.Printf("%T fields: %d\n", mru, len(mru))
-	// Output: map[string][]string fields: 3
+	// Output: map[string][]string fields: 4
 }
 
 func ExampleMatchingRule_Map() {
@@ -1328,7 +1328,7 @@ func ExampleMatchingRule_Map() {
 
 	mr := sch.MRC.Get(`2.5.13.1`).Map()
 	fmt.Printf("%T fields: %d\n", mr, len(mr))
-	// Output: map[string][]string fields: 4
+	// Output: map[string][]string fields: 5
 }
 
 func ExampleAttributeType_Map() {
@@ -1340,7 +1340,7 @@ func ExampleAttributeType_Map() {
 	myDef := `( 1.3.6.1.4.1.56521.999.104.17.2.1.10
                         NAME ( 'jessesNewAttr' 'jesseAltName' )
                         DESC 'This is an example AttributeType definition'
-                        SINGLE-VALUE SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+                        SINGLE-VALUE SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{64}
                         EQUALITY caseIgnoreMatch X-ORIGIN 'Jesse Coretta' )`
 
 	if err := sch.MarshalAttributeType(myDef); err != nil {
@@ -1349,7 +1349,7 @@ func ExampleAttributeType_Map() {
 
 	jattr := sch.ATC.Get(`jessesNewAttr`).Map()
 	fmt.Printf("%T fields: %d\n", jattr, len(jattr))
-	// Output: map[string][]string fields: 7
+	// Output: map[string][]string fields: 9
 }
 
 func ExampleObjectClass_Map() {
@@ -1374,7 +1374,7 @@ func ExampleObjectClass_Map() {
 
 	jclass := sch.OCC.Get(`jessesClass`).Map()
 	fmt.Printf("%T fields: %d\n", jclass, len(jclass))
-	// Output: map[string][]string fields: 8
+	// Output: map[string][]string fields: 9
 }
 
 func ExampleNameForm_Map() {
@@ -1399,7 +1399,7 @@ func ExampleNameForm_Map() {
 
 	jnf := sch.NFC.Get(`jesseNameForm`).Map()
 	fmt.Printf("%T fields: %d\n", jnf, len(jnf))
-	// Output: map[string][]string fields: 7
+	// Output: map[string][]string fields: 8
 }
 
 func ExampleDITStructureRule_Map() {
@@ -1433,7 +1433,7 @@ func ExampleDITStructureRule_Map() {
 
 	jdsr := sch.DSRC.Get(`jesseDSR`).Map()
 	fmt.Printf("%T fields: %d\n", jdsr, len(jdsr))
-	// Output: map[string][]string fields: 5
+	// Output: map[string][]string fields: 6
 }
 
 func ExampleUsage_Label() {

--- a/dsr.go
+++ b/dsr.go
@@ -388,6 +388,10 @@ func (r *DITStructureRule) Map() (def map[string][]string) {
 	def[`RAW`] = []string{r.String()}
 	def[`ID`] = []string{r.ID.String()}
 
+	if len(r.info) > 0 {
+		def[`INFO`] = []string{string(r.info)}
+	}
+
 	if !r.Name.IsZero() {
 		def[`NAME`] = make([]string, 0)
 		for i := 0; i < r.Name.Len(); i++ {

--- a/dsr.go
+++ b/dsr.go
@@ -387,6 +387,7 @@ func (r *DITStructureRule) Map() (def map[string][]string) {
 	def = make(map[string][]string, 14)
 	def[`RAW`] = []string{r.String()}
 	def[`ID`] = []string{r.ID.String()}
+	def[`TYPE`] = []string{r.Type()}
 
 	if len(r.info) > 0 {
 		def[`INFO`] = []string{string(r.info)}

--- a/dsr.go
+++ b/dsr.go
@@ -85,6 +85,13 @@ type SuperiorDITStructureRules struct {
 }
 
 /*
+Type returns the formal name of the receiver in order to satisfy signature requirements of the Definition interface type.
+*/
+func (r *DITStructureRule) Type() string {
+	return `DITStructureRule`
+}
+
+/*
 Equal performs a deep-equal between the receiver and the provided collection type.
 */
 func (r DITStructureRules) Equal(x DITStructureRuleCollection) bool {
@@ -378,6 +385,7 @@ func (r *DITStructureRule) Map() (def map[string][]string) {
 	}
 
 	def = make(map[string][]string, 14)
+	def[`RAW`] = []string{r.String()}
 	def[`ID`] = []string{r.ID.String()}
 
 	if !r.Name.IsZero() {
@@ -418,11 +426,11 @@ func (r *DITStructureRule) Map() (def map[string][]string) {
 }
 
 /*
-DITStructureRuleUnmarshalFunction is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *DITStructureRule) DITStructureRuleUnmarshalFunc() (def string, err error) {
+func (r *DITStructureRule) UnmarshalFunc() (def string, err error) {
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/ls.go
+++ b/ls.go
@@ -330,6 +330,10 @@ func (r *LDAPSyntax) Map() (def map[string][]string) {
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
+	if len(r.info) > 0 {
+		def[`INFO`] = []string{string(r.info)}
+	}
+
 	if len(r.Description) > 0 {
 		def[`DESC`] = []string{r.Description.String()}
 	}

--- a/ls.go
+++ b/ls.go
@@ -329,6 +329,7 @@ func (r *LDAPSyntax) Map() (def map[string][]string) {
 	def = make(map[string][]string, 14)
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
+	def[`TYPE`] = []string{r.Type()}
 
 	if len(r.info) > 0 {
 		def[`INFO`] = []string{string(r.info)}

--- a/ls.go
+++ b/ls.go
@@ -67,6 +67,13 @@ type LDAPSyntaxes struct {
 }
 
 /*
+Type returns the formal name of the receiver in order to satisfy signature requirements of the Definition interface type.
+*/
+func (r *LDAPSyntax) Type() string {
+	return `LDAPSyntax`
+}
+
+/*
 Equal performs a deep-equal between the receiver and the provided collection type.
 */
 func (r LDAPSyntaxes) Equal(x LDAPSyntaxCollection) bool {
@@ -275,11 +282,11 @@ func (r *LDAPSyntax) unmarshal() (string, error) {
 }
 
 /*
-LDAPSyntaxUnmarshalFunction is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *LDAPSyntax) LDAPSyntaxUnmarshalFunc() (def string, err error) {
+func (r *LDAPSyntax) UnmarshalFunc() (def string, err error) {
 
 	var (
 		WHSP string = ` `
@@ -320,6 +327,7 @@ func (r *LDAPSyntax) Map() (def map[string][]string) {
 	}
 
 	def = make(map[string][]string, 14)
+	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
 	if len(r.Description) > 0 {

--- a/mr.go
+++ b/mr.go
@@ -368,6 +368,10 @@ func (r *MatchingRule) Map() (def map[string][]string) {
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
+	if len(r.info) > 0 {
+		def[`INFO`] = []string{string(r.info)}
+	}
+
 	if !r.Name.IsZero() {
 		def[`NAME`] = make([]string, 0)
 		for i := 0; i < r.Name.Len(); i++ {

--- a/mr.go
+++ b/mr.go
@@ -81,6 +81,13 @@ type Substring struct {
 }
 
 /*
+Type returns the formal name of the receiver in order to satisfy signature requirements of the Definition interface type.
+*/
+func (r *MatchingRule) Type() string {
+	return `MatchingRule`
+}
+
+/*
 Equal performs a deep-equal between the receiver and the provided definition type.
 
 Description text is ignored.
@@ -358,6 +365,7 @@ func (r *MatchingRule) Map() (def map[string][]string) {
 	}
 
 	def = make(map[string][]string, 14)
+	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
 	if !r.Name.IsZero() {
@@ -389,11 +397,11 @@ func (r *MatchingRule) Map() (def map[string][]string) {
 }
 
 /*
-MatchingRuleUnmarshalFunction is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *MatchingRule) MatchingRuleUnmarshalFunc() (def string, err error) {
+func (r *MatchingRule) UnmarshalFunc() (def string, err error) {
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/mr.go
+++ b/mr.go
@@ -367,6 +367,7 @@ func (r *MatchingRule) Map() (def map[string][]string) {
 	def = make(map[string][]string, 14)
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
+	def[`TYPE`] = []string{r.Type()}
 
 	if len(r.info) > 0 {
 		def[`INFO`] = []string{string(r.info)}

--- a/mru.go
+++ b/mru.go
@@ -457,6 +457,7 @@ func (r *MatchingRuleUse) Map() (def map[string][]string) {
 	def = make(map[string][]string, 14)
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
+	def[`TYPE`] = []string{r.Type()}
 
 	if len(r.info) > 0 {
 		def[`INFO`] = []string{string(r.info)}

--- a/mru.go
+++ b/mru.go
@@ -458,6 +458,10 @@ func (r *MatchingRuleUse) Map() (def map[string][]string) {
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
+	if len(r.info) > 0 {
+		def[`INFO`] = []string{string(r.info)}
+	}
+
 	if !r.Name.IsZero() {
 		def[`NAME`] = make([]string, 0)
 		for i := 0; i < r.Name.Len(); i++ {

--- a/mru.go
+++ b/mru.go
@@ -73,6 +73,13 @@ type MatchingRuleUses struct {
 }
 
 /*
+Type returns the formal name of the receiver in order to satisfy signature requirements of the Definition interface type.
+*/
+func (r *MatchingRuleUse) Type() string {
+	return `MatchingRuleUse`
+}
+
+/*
 Equal performs a deep-equal between the receiver and the provided collection type.
 */
 func (r MatchingRuleUses) Equal(x MatchingRuleUseCollection) bool {
@@ -448,6 +455,7 @@ func (r *MatchingRuleUse) Map() (def map[string][]string) {
 	}
 
 	def = make(map[string][]string, 14)
+	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
 	if !r.Name.IsZero() {
@@ -487,11 +495,11 @@ func (r *MatchingRuleUse) Map() (def map[string][]string) {
 }
 
 /*
-MatchingRuleUseUnmarshalFunction is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *MatchingRuleUse) MatchingRuleUseUnmarshalFunc() (def string, err error) {
+func (r *MatchingRuleUse) UnmarshalFunc() (def string, err error) {
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/nf.go
+++ b/nf.go
@@ -348,6 +348,7 @@ func (r *NameForm) Map() (def map[string][]string) {
 	def = make(map[string][]string, 14)
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
+	def[`TYPE`] = []string{r.Type()}
 
 	if len(r.info) > 0 {
 		def[`INFO`] = []string{string(r.info)}

--- a/nf.go
+++ b/nf.go
@@ -349,6 +349,10 @@ func (r *NameForm) Map() (def map[string][]string) {
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
+	if len(r.info) > 0 {
+		def[`INFO`] = []string{string(r.info)}
+	}
+
 	if !r.Name.IsZero() {
 		def[`NAME`] = make([]string, 0)
 		for i := 0; i < r.Name.Len(); i++ {

--- a/nf.go
+++ b/nf.go
@@ -71,6 +71,13 @@ type NameForms struct {
 }
 
 /*
+Type returns the formal name of the receiver in order to satisfy signature requirements of the Definition interface type.
+*/
+func (r *NameForm) Type() string {
+	return `NameForm`
+}
+
+/*
 Equal performs a deep-equal between the receiver and the provided collection type.
 */
 func (r NameForms) Equal(x NameFormCollection) bool {
@@ -339,6 +346,7 @@ func (r *NameForm) Map() (def map[string][]string) {
 	}
 
 	def = make(map[string][]string, 14)
+	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 
 	if !r.Name.IsZero() {
@@ -394,11 +402,11 @@ func (r *NameForm) Map() (def map[string][]string) {
 }
 
 /*
-NameFormUnmarshalFunction is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *NameForm) NameFormUnmarshalFunc() (def string, err error) {
+func (r *NameForm) UnmarshalFunc() (def string, err error) {
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/oc.go
+++ b/oc.go
@@ -86,6 +86,13 @@ type ObjectClass struct {
 }
 
 /*
+Type returns the formal name of the receiver in order to satisfy signature requirements of the Definition interface type.
+*/
+func (r *ObjectClass) Type() string {
+	return `ObjectClass`
+}
+
+/*
 ObjectClasses is a thread-safe collection of *ObjectClass slice instances.
 */
 type ObjectClasses struct {
@@ -550,6 +557,7 @@ func (r *ObjectClass) Map() (def map[string][]string) {
 	}
 
 	def = make(map[string][]string, 14)
+	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 	def[`KIND`] = []string{r.Kind.String()}
 
@@ -614,11 +622,11 @@ func (r *ObjectClass) Map() (def map[string][]string) {
 }
 
 /*
-ObjectClassUnmarshalFunction is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *ObjectClass) ObjectClassUnmarshalFunc() (def string, err error) {
+func (r *ObjectClass) UnmarshalFunc() (def string, err error) {
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/oc.go
+++ b/oc.go
@@ -560,6 +560,7 @@ func (r *ObjectClass) Map() (def map[string][]string) {
 	def[`RAW`] = []string{r.String()}
 	def[`OID`] = []string{r.OID.String()}
 	def[`KIND`] = []string{r.Kind.String()}
+	def[`TYPE`] = []string{r.Type()}
 
 	if len(r.info) > 0 {
 		def[`INFO`] = []string{string(r.info)}

--- a/oc.go
+++ b/oc.go
@@ -561,6 +561,10 @@ func (r *ObjectClass) Map() (def map[string][]string) {
 	def[`OID`] = []string{r.OID.String()}
 	def[`KIND`] = []string{r.Kind.String()}
 
+	if len(r.info) > 0 {
+		def[`INFO`] = []string{string(r.info)}
+	}
+
 	if !r.Name.IsZero() {
 		def[`NAME`] = make([]string, 0)
 		for i := 0; i < r.Name.Len(); i++ {


### PR DESCRIPTION
## v.0.0.6-alpha

- `Type()` function now added for all Definition `interface` types to return the formal string name of the definition type (e.g.: `AttributeType`).  Useful in type casing when an input argument type is `schemax.Definition`.
- `<TYPE>`-based Map() instances now include a `RAW` field to store the unmarshaled form of the receiver, and will honor the UnmarshalFunc that is set in the receiver (if any) during string casting.
- `<TYPE>`-based Map() instances now include a `TYPE` field to store the formal name of the definition type for convenience.
- `schemax.AttributeType`-based `Map()` instances now include a `MUB` field if a minimum-upper bounds was set
- `<TYPE>UnmarshalFunc()` methods renamed to just `UnmarshalFunc()`
