### PR TITLE
v0.0.8-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Types provided by this package are created based on the precepts of RFC2252 and 
 
 LDAP directories contain and serve data in a hierarchical manner. The syntax and evaluation of this data is governed by a schema, which itself is hierarchical in nature.
 
-The nature of this package's operation is highly referential. Objects are referenced via pointers, and these objects can inhabit multiple other multi-valued types. For example, `*AttributeType` instances are stored within a type-specific map type called a manifest. Each `*AttributeType` that exists can be referenced by other `*AttributeType` instances (in a scenario where "super typing" is in effect), or by other `*ObjectClass` instances via their own PermittedAttributeTypes (May) and RequiredAttributeTypes (Must) list types. Literal "copies" of single objects are never made. References are always through pointers.
+The nature of this package's operation is highly referential. Objects are referenced via pointers, and these objects can inhabit multiple other multi-valued types. For example, `*AttributeType` instances are stored within a type-specific slices called collections. Each `*AttributeType` that exists can be referenced by other `*AttributeType` instances (in a scenario where "super typing" is in effect), or by other `*ObjectClass` instances via their own PermittedAttributeTypes (May) and RequiredAttributeTypes (Must) list types. Literal "copies" of single objects are never made. References are always through pointers.
 
 ## Intended Audience
 

--- a/_examples/main_example_fileparse.go
+++ b/_examples/main_example_fileparse.go
@@ -1,0 +1,156 @@
+/*
+Author: Jesse Coretta - for github.com/JesseCoretta/go-schemax/_examples
+
+This example describes a basic file parse of an LDAP schema in RFC4512 compliant format.
+
+What happens:
+
+ - Each definition is parsed as specific type instances (e.g.: *AttributeType, *DITContentRule, et al)
+ - Each type is then assigned a desired unmarshaler function and then printed back to string
+*/
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strings"
+
+	"github.com/JesseCoretta/go-schemax"
+)
+
+func main() {
+
+	file := `/tmp/my.schema` // update as needed
+
+	// quick error handler
+	chkerr := func(err error) {
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+	hasPrefix := func(line, pfx string) bool {
+		if strings.HasPrefix(strings.ToLower(line), pfx) {
+			return true
+		}
+		return false
+	}
+
+	// read file into bytes
+	data, err := ioutil.ReadFile(file)
+	chkerr(err)
+
+	proc := strings.ReplaceAll(string(data), "\n\t", " ")
+	data = []byte(proc)
+
+	// Make a schema object
+	sch := schemax.NewSubschema()
+	sch.PopulateDefaultLDAPSyntaxes()
+	sch.PopulateDefaultMatchingRules()
+
+	// Split "data" ([]byte) into string slices, delimited on the
+	// newline character. Each slice represents a single line and
+	// (possibly) a schema definition ...
+	lines := strings.Split(string(data), "\n")
+
+	// Iterate over each perceived line, and evaluate the raw text
+	// to ascertain if it is a known definition type. If not recognized,
+	// then take no action. If recognized, then unmarshal.
+	for idx, line := range lines {
+
+		// Ignore any purely empty lines
+		if len(line) == 0 {
+			continue
+		}
+
+		// Ignore any lines we believe are comments
+		if line[0] == '#' {
+			continue
+		}
+
+		// Look for a definition specifier (e.g.: "attributetype")
+		// as the first component of each line. Please keep in mind
+		// that these specifiers are known to vary across schema
+		// standards adopted in different LDAP products, such as
+		// Netscape vs. OpenLDAP ...
+		switch {
+		case hasPrefix(line, `ldapsyntax`):
+			err = sch.MarshalLDAPSyntax(line)
+		case hasPrefix(line, `matchingrule`):
+			err = sch.MarshalMatchingRule(line)
+		case hasPrefix(line, `attributetype`):
+			err = sch.MarshalAttributeType(line)
+		case hasPrefix(line, `objectclass`):
+			err = sch.MarshalObjectClass(line)
+		case hasPrefix(line, `ditcontentrule`):
+			err = sch.MarshalDITContentRule(line)
+		case hasPrefix(line, `nameform`):
+			err = sch.MarshalNameForm(line)
+		case hasPrefix(line, `ditstructurerule`):
+			err = sch.MarshalDITStructureRule(line)
+		default:
+			err = fmt.Errorf("Unrecognized definition on, or around, line #%d: %s", idx+1, line)
+		}
+
+		chkerr(err)
+	}
+
+	// Now that all ATs are loaded, refresh the
+	// manifest of applied MatchingRuleUses ...
+	sch.MRUC.Refresh(sch.ATC)
+
+	// Use the pretty package-provided unmarshaler
+	// funcs to print with nice indenting and linebreaks,
+	// and set our desired specifier for each collection.
+	var raw string
+
+	sch.LSC.SetSpecifier(`ldapsyntax`)
+	sch.LSC.SetUnmarshaler(schemax.LDAPSyntaxUnmarshaler)
+	raw, err = schemax.Unmarshal(sch.LSC)
+	chkerr(err)
+	fmt.Printf("%s\n", raw)
+
+	sch.MRC.SetSpecifier(`matchingrule`)
+	sch.MRC.SetUnmarshaler(schemax.MatchingRuleUnmarshaler)
+	raw, err = schemax.Unmarshal(sch.MRC)
+	chkerr(err)
+	fmt.Printf("%s\n", raw)
+
+	sch.ATC.SetSpecifier(`attributetype`)
+	sch.ATC.SetUnmarshaler(schemax.AttributeTypeUnmarshaler)
+	raw, err = schemax.Unmarshal(sch.ATC)
+	chkerr(err)
+	fmt.Printf("%s\n", raw)
+
+	sch.MRUC.SetSpecifier(`matchingruleuse`)
+	sch.MRUC.SetUnmarshaler(schemax.MatchingRuleUseUnmarshaler)
+	raw, err = schemax.Unmarshal(sch.MRUC)
+	chkerr(err)
+	fmt.Printf("%s\n", raw)
+
+	sch.OCC.SetSpecifier(`objectclass`)
+	sch.OCC.SetUnmarshaler(schemax.ObjectClassUnmarshaler)
+	raw, err = schemax.Unmarshal(sch.OCC)
+	chkerr(err)
+	fmt.Printf("%s\n", raw)
+
+	sch.DCRC.SetSpecifier(`ditcontentrule`)
+	sch.DCRC.SetUnmarshaler(schemax.DITContentRuleUnmarshaler)
+	raw, err = schemax.Unmarshal(sch.DCRC)
+	chkerr(err)
+	fmt.Printf("%s\n", raw)
+
+	sch.NFC.SetSpecifier(`nameform`)
+	sch.NFC.SetUnmarshaler(schemax.NameFormUnmarshaler)
+	raw, err = schemax.Unmarshal(sch.NFC)
+	chkerr(err)
+	fmt.Printf("%s\n", raw)
+
+	sch.DSRC.SetSpecifier(`ditstructurerule`)
+	sch.DSRC.SetUnmarshaler(schemax.DITStructureRuleUnmarshaler)
+	raw, err = schemax.Unmarshal(sch.DSRC)
+	chkerr(err)
+	fmt.Printf("%s\n", raw)
+
+	return
+}

--- a/_examples/main_example_ldap.go
+++ b/_examples/main_example_ldap.go
@@ -155,8 +155,6 @@ func main() {
 				err = subschema.MarshalMatchingRule(def)
 			case `attributeTypes`:
 				err = subschema.MarshalAttributeType(def)
-			case `matchingRuleUses`:
-				//err = subschema.MarshalMatchingRuleUse(def)
 			case `objectClasses`:
 				err = subschema.MarshalObjectClass(def)
 			case `dITContentRules`:
@@ -176,80 +174,100 @@ func main() {
 		chkerr(subschema.MRUC.Refresh(subschema.ATC))
 	}
 
+	// Set our specifiers and our desired unmarshal func.
+	subschema.LSC.SetSpecifier(`ldapsyntax`)
+	if subschema.LSC.Len() > 0 {
+		subschema.LSC.SetUnmarshalFunc(subschema.LSC.Index(0).UnmarshalFunc)
+	}
+
+	subschema.MRC.SetSpecifier(`matchingrule`)
+	subschema.MRC.SetUnmarshalFunc((&schemax.MatchingRule{}).UnmarshalFunc)
+
+	subschema.MRC.SetSpecifier(`matchingruleuse`)
+	subschema.MRC.SetUnmarshalFunc((&schemax.MatchingRuleUse{}).UnmarshalFunc)
+
+	subschema.MRC.SetSpecifier(`attributetype`)
+	subschema.MRC.SetUnmarshalFunc((&schemax.AttributeType{}).UnmarshalFunc)
+
+	subschema.MRC.SetSpecifier(`objectclass`)
+	subschema.MRC.SetUnmarshalFunc((&schemax.ObjectClass{}).UnmarshalFunc)
+
+	subschema.MRC.SetSpecifier(`ditcontentrule`)
+	subschema.MRC.SetUnmarshalFunc((&schemax.DITContentRule{}).UnmarshalFunc)
+
+	subschema.MRC.SetSpecifier(`nameform`)
+	subschema.MRC.SetUnmarshalFunc((&schemax.NameForm{}).UnmarshalFunc)
+
+	subschema.MRC.SetSpecifier(`ditstructurerule`)
+	subschema.MRC.SetUnmarshalFunc((&schemax.DITStructureRule{}).UnmarshalFunc)
+
 	fmt.Printf("############################################################\n")
 	fmt.Printf("## BEGIN SCHEMA %s\n\n", subschema.DN)
 
-	fmt.Printf("\n############################################################\n")
-	fmt.Printf("## Parsed ldapSyntaxes: %d\n\n", subschema.LSC.Len())
-	for i := 0; i < subschema.LSC.Len(); i++ {
-		def := subschema.LSC.Index(i)
-		def.SetSpecifier(`ldapsyntax`)
-		def.SetUnmarshalFunc(def.LDAPSyntaxUnmarshalFunc)
-		fmt.Printf("%s\n\n", def.String())
+	if ls, err := schemax.Unmarshal(subschema.LSC); err != nil {
+		fmt.Println(err)
+		return
+	} else {
+		fmt.Printf("\n############################################################\n")
+		fmt.Printf("## Parsed ldapSyntaxes: %d\n\n", subschema.LSC.Len())
+		fmt.Printf("%s\n", ls)
 	}
 
-	fmt.Printf("\n############################################################\n")
-	fmt.Printf("## Parsed matchingRules: %d\n\n", subschema.MRC.Len())
-	for i := 0; i < subschema.MRC.Len(); i++ {
-		def := subschema.MRC.Index(i)
-		def.SetSpecifier(`matchingrule`)
-		def.SetUnmarshalFunc(def.MatchingRuleUnmarshalFunc)
-		fmt.Printf("%s\n\n", def.String())
-	}
+        if mr, err := schemax.Unmarshal(subschema.MRC); err != nil {
+                fmt.Println(err)
+        } else {
+                fmt.Printf("\n############################################################\n")
+		fmt.Printf("## Parsed matchingRules: %d\n\n", subschema.MRC.Len())
+                fmt.Printf("%s\n", mr)
+        }
 
-	fmt.Printf("\n############################################################\n")
-	fmt.Printf("## Parsed attributeTypes: %d\n\n", subschema.ATC.Len())
-	for i := 0; i < subschema.ATC.Len(); i++ {
-		def := subschema.ATC.Index(i)
-		def.SetSpecifier(`attributetype`)
-		def.SetUnmarshalFunc(def.AttributeTypeUnmarshalFunc)
-		fmt.Printf("%s\n\n", def.String())
-	}
+        if at, err := schemax.Unmarshal(subschema.ATC); err != nil {
+                fmt.Println(err)
+        } else {
+                fmt.Printf("\n############################################################\n")
+		fmt.Printf("## Parsed attributeTypes: %d\n\n", subschema.ATC.Len())
+                fmt.Printf("%s\n", at)
+        }
 
-	fmt.Printf("\n############################################################\n")
-	fmt.Printf("## Parsed matchingRuleUses:%d\n\n", subschema.MRUC.Len())
-	for i := 0; i < subschema.MRUC.Len(); i++ {
-		def := subschema.MRUC.Index(i)
-		def.SetSpecifier(`matchingruleuse`)
-		def.SetUnmarshalFunc(def.MatchingRuleUseUnmarshalFunc)
-		fmt.Printf("%s\n\n", def.String())
-	}
+        if mru, err := schemax.Unmarshal(subschema.MRUC); err != nil {
+                fmt.Println(err)
+        } else {
+                fmt.Printf("\n############################################################\n")
+		fmt.Printf("## Parsed matchingRuleUses: %d\n\n", subschema.MRUC.Len())
+                fmt.Printf("%s\n", mru)
+        }
 
-	fmt.Printf("\n############################################################\n")
-	fmt.Printf("## Parsed objectClasses: %d\n\n", subschema.OCC.Len())
-	for i := 0; i < subschema.OCC.Len(); i++ {
-		def := subschema.OCC.Index(i)
-		def.SetSpecifier(`objectclass`)
-		def.SetUnmarshalFunc(def.ObjectClassUnmarshalFunc)
-		fmt.Printf("%s\n\n", def.String())
-	}
+        if oc, err := schemax.Unmarshal(subschema.OCC); err != nil {
+                fmt.Println(err)
+        } else {
+                fmt.Printf("\n############################################################\n")
+		fmt.Printf("## Parsed objectClasses: %d\n\n", subschema.OCC.Len())
+                fmt.Printf("%s\n", oc)
+        }
 
-	fmt.Printf("\n############################################################\n")
-	fmt.Printf("## Parsed dITContentRules: %d\n\n", subschema.DCRC.Len())
-	for i := 0; i < subschema.DCRC.Len(); i++ {
-		def := subschema.DCRC.Index(i)
-		def.SetSpecifier(`ditcontentrule`)
-		def.SetUnmarshalFunc(def.DITContentRuleUnmarshalFunc)
-		fmt.Printf("%s\n\n", def.String())
-	}
+        if dcr, err := schemax.Unmarshal(subschema.DCRC); err != nil {
+                fmt.Println(err)
+        } else {
+                fmt.Printf("\n############################################################\n")
+		fmt.Printf("## Parsed dITContentRules: %d\n\n", subschema.DCRC.Len())
+                fmt.Printf("%s\n", dcr)
+        }
 
-	fmt.Printf("\n############################################################\n")
-	fmt.Printf("## Parsed nameForms: %d\n\n", subschema.NFC.Len())
-	for i := 0; i < subschema.NFC.Len(); i++ {
-		def := subschema.NFC.Index(i)
-		def.SetSpecifier(`nameform`)
-		def.SetUnmarshalFunc(def.NameFormUnmarshalFunc)
-		fmt.Printf("%s\n\n", def.String())
-	}
+        if nf, err := schemax.Unmarshal(subschema.NFC); err != nil {
+                fmt.Println(err)
+        } else {
+                fmt.Printf("\n############################################################\n")
+		fmt.Printf("## Parsed nameForms: %d\n\n", subschema.NFC.Len())
+                fmt.Printf("%s\n", nf)
+        }
 
-	fmt.Printf("\n############################################################\n")
-	fmt.Printf("## Parsed dITStructureRules: %d\n\n", subschema.DSRC.Len())
-	for i := 0; i < subschema.DSRC.Len(); i++ {
-		def := subschema.DSRC.Index(i)
-		def.SetSpecifier(`ditstructurerule`)
-		def.SetUnmarshalFunc(def.DITStructureRuleUnmarshalFunc)
-		fmt.Printf("%s\n\n", def.String())
-	}
+        if dsr, err := schemax.Unmarshal(subschema.DSRC); err != nil {
+                fmt.Println(err)
+        } else {
+                fmt.Printf("\n############################################################\n")
+		fmt.Printf("## Parsed dITStructureRules: %d\n\n", subschema.DSRC.Len())
+                fmt.Printf("%s\n", dsr)
+        }
 
 	fmt.Printf("\n## END SCHEMA\n")
 	fmt.Printf("##########################\n\n")

--- a/_examples/main_example_ldap.go
+++ b/_examples/main_example_ldap.go
@@ -174,32 +174,30 @@ func main() {
 		chkerr(subschema.MRUC.Refresh(subschema.ATC))
 	}
 
-	// Set our specifiers and our desired unmarshal func.
+	// Set our specifiers and our desired unmarshal funcs.
 	subschema.LSC.SetSpecifier(`ldapsyntax`)
-	if subschema.LSC.Len() > 0 {
-		subschema.LSC.SetUnmarshalFunc(subschema.LSC.Index(0).UnmarshalFunc)
-	}
+	subschema.LSC.SetUnmarshaler(schemax.LDAPSyntaxUnmarshaler)
 
 	subschema.MRC.SetSpecifier(`matchingrule`)
-	subschema.MRC.SetUnmarshalFunc((&schemax.MatchingRule{}).UnmarshalFunc)
+	subschema.MRC.SetUnmarshaler(schemax.MatchingRuleUnmarshaler)
 
-	subschema.MRC.SetSpecifier(`matchingruleuse`)
-	subschema.MRC.SetUnmarshalFunc((&schemax.MatchingRuleUse{}).UnmarshalFunc)
+	subschema.ATC.SetSpecifier(`attributetype`)
+	subschema.ATC.SetUnmarshaler(schemax.AttributeTypeUnmarshaler)
 
-	subschema.MRC.SetSpecifier(`attributetype`)
-	subschema.MRC.SetUnmarshalFunc((&schemax.AttributeType{}).UnmarshalFunc)
+	subschema.MRUC.SetSpecifier(`matchingruleuse`)
+	subschema.MRUC.SetUnmarshaler(schemax.MatchingRuleUseUnmarshaler)
 
-	subschema.MRC.SetSpecifier(`objectclass`)
-	subschema.MRC.SetUnmarshalFunc((&schemax.ObjectClass{}).UnmarshalFunc)
+	subschema.OCC.SetSpecifier(`objectclass`)
+	subschema.OCC.SetUnmarshaler(schemax.ObjectClassUnmarshaler)
 
-	subschema.MRC.SetSpecifier(`ditcontentrule`)
-	subschema.MRC.SetUnmarshalFunc((&schemax.DITContentRule{}).UnmarshalFunc)
+	subschema.DCRC.SetSpecifier(`ditcontentrule`)
+	subschema.DCRC.SetUnmarshaler(schemax.DITContentRuleUnmarshaler)
 
-	subschema.MRC.SetSpecifier(`nameform`)
-	subschema.MRC.SetUnmarshalFunc((&schemax.NameForm{}).UnmarshalFunc)
+	subschema.NFC.SetSpecifier(`nameform`)
+	subschema.NFC.SetUnmarshaler(schemax.NameFormUnmarshaler)
 
-	subschema.MRC.SetSpecifier(`ditstructurerule`)
-	subschema.MRC.SetUnmarshalFunc((&schemax.DITStructureRule{}).UnmarshalFunc)
+	subschema.DSRC.SetSpecifier(`ditstructurerule`)
+	subschema.DSRC.SetUnmarshaler(schemax.DITStructureRuleUnmarshaler)
 
 	fmt.Printf("############################################################\n")
 	fmt.Printf("## BEGIN SCHEMA %s\n\n", subschema.DN)

--- a/dcr.go
+++ b/dcr.go
@@ -6,10 +6,6 @@ import "sync"
 DITContentRuleCollection describes all DITContentRules-based types.
 */
 type DITContentRuleCollection interface {
-	// Contains returns the index number and presence boolean that
-	// reflects the result of a term search within the receiver.
-	Contains(interface{}) (int, bool)
-
 	// Get returns the *DITContentRule instance retrieved as a result
 	// of a term search, based on Name or OID. If no match is found,
 	// nil is returned.
@@ -27,21 +23,38 @@ type DITContentRuleCollection interface {
 	// the provided *DITContentRule instance to the receiver.
 	Set(*DITContentRule) error
 
-	// String returns a properly-delimited sequence of string
-	// values, either as a Name or OID, for the receiver type.
-	String() string
+        // Contains returns the index number and presence boolean that
+        // reflects the result of a term search within the receiver.
+        Contains(interface{}) (int, bool)
 
-	// Label returns the field name associated with the interface
-	// types, or a zero string if no label is appropriate.
-	Label() string
+        // String returns a properly-delimited sequence of string
+        // values, either as a Name or OID, for the receiver type.
+        String() string
 
-	// IsZero returns a boolean value indicative of whether the
-	// receiver is considered zero, or undefined.
-	IsZero() bool
+        // Label returns the field name associated with the interface
+        // types, or a zero string if no label is appropriate.
+        Label() string
 
-	// Len returns an integer value indicative of the current
-	// number of elements stored within the receiver.
-	Len() int
+        // IsZero returns a boolean value indicative of whether the
+        // receiver is considered zero, or undefined.
+        IsZero() bool
+
+        // Len returns an integer value indicative of the current
+        // number of elements stored within the receiver.
+        Len() int
+
+        // SetSpecifier assigns a string value to all definitions within
+        // the receiver. This value is used in cases where a definition
+        // type name (e.g.: attributetype, objectclass, etc.) is required.
+        // This value will be displayed at the beginning of the definition
+        // value during the unmarshal or unsafe stringification process.
+        SetSpecifier(string)
+
+        // SetUnmarshaler assigns the provided DefinitionUnmarshaler
+        // signature to all definitions within the receiver. The provided
+        // function shall be executed during the unmarshal or unsafe
+        // stringification process.
+        SetUnmarshaler(DefinitionUnmarshaler)
 }
 
 /*
@@ -59,7 +72,7 @@ type DITContentRule struct {
 	Not         AttributeTypeCollection
 	Extensions  Extensions
 	flags       definitionFlags
-	ufn         DefinitionUnmarshalFunc
+	ufn         DefinitionUnmarshaler
 	spec        string
 	info        []byte
 }
@@ -95,6 +108,24 @@ func (r *DITContentRules) SetMacros(macros *Macros) {
 }
 
 /*
+SetSpecifier is a convenience method that executes the SetSpecifier method in iterative fashion for all definitions within the receiver.
+*/
+func (r *DITContentRules) SetSpecifier(spec string) {
+        for i := 0; i < r.Len(); i++ {
+                r.Index(i).SetSpecifier(spec)
+        }
+}
+
+/*
+SetUnmarshaler is a convenience method that executes the SetUnmarshaler method in iterative fashion for all definitions within the receiver.
+*/
+func (r *DITContentRules) SetUnmarshaler(fn DefinitionUnmarshaler) {
+        for i := 0; i < r.Len(); i++ {
+                r.Index(i).SetUnmarshaler(fn)
+        }
+}
+
+/*
 SetInfo assigns the byte slice to the receiver. This is a user-leveraged field intended to allow arbitrary information (documentation?) to be assigned to the definition.
 */
 func (r *DITContentRule) SetInfo(info []byte) {
@@ -109,9 +140,9 @@ func (r *DITContentRule) Info() []byte {
 }
 
 /*
-SetUnmarshalFunc assigns the provided DefinitionUnmarshalFunc signature value to the receiver. The provided function shall be executed during the unmarshal or unsafe stringification process.
+SetUnmarshaler assigns the provided DefinitionUnmarshaler signature value to the receiver. The provided function shall be executed during the unmarshal or unsafe stringification process.
 */
-func (r *DITContentRule) SetUnmarshalFunc(fn DefinitionUnmarshalFunc) {
+func (r *DITContentRule) SetUnmarshaler(fn DefinitionUnmarshaler) {
 	r.ufn = fn
 }
 
@@ -164,7 +195,7 @@ func (r DITContentRules) Len() int {
 }
 
 /*
-String is a stringer method used to return the properly-delimited and formatted series of attributeType name or OID definitions.
+String is a non-functional stringer method needed to satisfy interface type requirements and should not be used. There is no practical application for a list of dITContentRule names or object identifiers in this package.
 */
 func (r DITContentRules) String() string { return `` }
 
@@ -345,7 +376,7 @@ func (r *DITContentRule) unmarshal() (string, error) {
 	}
 
 	if r.ufn != nil {
-		return r.ufn()
+		return r.ufn(r)
 	}
 	return r.unmarshalBasic()
 }
@@ -440,11 +471,25 @@ func (r *DITContentRule) Map() (def map[string][]string) {
 }
 
 /*
-UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+DITContentRuleUnmarshaler is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshaler type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *DITContentRule) UnmarshalFunc() (def string, err error) {
+func DITContentRuleUnmarshaler(x interface{}) (def string, err error) {
+        var r *DITContentRule
+        switch tv := x.(type) {
+        case *DITContentRule:
+                if tv.IsZero() {
+                        err = raise(isZero, "%T is nil", tv)
+                        return
+                }
+                r = tv
+        default:
+                err = raise(unexpectedType,
+                        "Bad type for unmarshal (%T)", tv)
+                return
+        }
+
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/def.go
+++ b/def.go
@@ -85,18 +85,29 @@ type Definition interface {
 	// unmarshal or unsafe stringification process.
 	SetSpecifier(string)
 
-	// SetUnmarshalFunc assigns the provided DefinitionUnmarshalFunc signature
+	// SetUnmarshaler assigns the provided DefinitionUnmarshaler signature
 	// value to the receiver. The provided function shall be executed during the
 	// unmarshal or unsafe stringification process.
-	SetUnmarshalFunc(DefinitionUnmarshalFunc)
+	SetUnmarshaler(DefinitionUnmarshaler)
 
-	// UnmarshalFunc is a package-included function that honors the signature
-	// of the first class (closure) DefinitionUnmarshalFunc type. The purpose
-	// of this function, and similar user-devised ones, is to help unmarshal
-	// a definition with specific formatting included, such as linebreaks,
-	// leading specifier declarations and indenting.
-	UnmarshalFunc() (string, error)
+	// unmarshal is for internal use only
+	unmarshal() (string, error)
 }
+
+/*
+DefinitionUnmarshaler is a first-class "closure" function intended for use in situations where it is desirable to format a given definition during the unmarshal process, i.e.: to add indents and linebreaks.
+
+During the unmarshaling or unsafe stringifaction processes, users may choose to:
+
+• Perform NO formatting whatsoever, producing definitions that span only a single line, or ...
+
+• Use the package-provided formatting closure function appropriate for the definition type, or ...
+
+• Define a custom unmarshal function that honors the defined signature of this type
+
+By default, NO special formatting is performed during unmarshaling or unsafe stringification of definitions.
+*/
+type DefinitionUnmarshaler func(interface{}) (string, error)
 
 /*
 OID is a type alias for []int that describes an ASN.1 Object Identifier.

--- a/doc_test.go
+++ b/doc_test.go
@@ -362,7 +362,7 @@ func ExampleMarshal_newAttributeTypeWithFormatting() {
                 EQUALITY caseIgnoreMatch X-ORIGIN 'Jesse Coretta' )`
 
         var x AttributeType
-	x.SetUnmarshalFunc(x.AttributeTypeUnmarshalFunc)
+	x.SetUnmarshaler(x.AttributeTypeUnmarshalFunc)
         err := Marshal(def, &x, nil, nil, lsc, mrc, nil, nil, nil, nil)
         if err != nil {
                 panic(err)

--- a/init.go
+++ b/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/JesseCoretta/go-schemax/rfc4519"
 	"github.com/JesseCoretta/go-schemax/rfc4523"
 	"github.com/JesseCoretta/go-schemax/rfc4524"
+	"github.com/JesseCoretta/go-schemax/rfc4530"
 )
 
 ////////////////
@@ -29,12 +30,15 @@ Within this structure are all of the following:
 • Syntax definitions from RFC4517 (imported from go-schemax/rfc4517)
 
 • Syntax definitions from RFC4523 (imported from go-schemax/rfc4523)
+
+• Syntax definitions from RFC4530 (imported from go-schemax/rfc4530)
 */
 func PopulateDefaultLDAPSyntaxes() (lsc LDAPSyntaxCollection) {
 	lsc = NewLDAPSyntaxes()
 	PopulateRFC2307Syntaxes(lsc)
 	PopulateRFC4517Syntaxes(lsc)
 	PopulateRFC4523Syntaxes(lsc)
+	PopulateRFC4530Syntaxes(lsc)
 
 	return
 }
@@ -84,21 +88,41 @@ func PopulateRFC4517Syntaxes(lsc LDAPSyntaxCollection) {
 	}
 }
 
+/*
+PopulateRFC4530Syntaxes only populates the provided LDAPSyntaxes (lsc) with LDAPSyntax definitions defined in this RFC.
+
+Definitions are imported from go-schemax/rfc4530.
+*/
+func PopulateRFC4530Syntaxes(lsc LDAPSyntaxCollection) {
+        for _, ls := range rfc4530.AllLDAPSyntaxes {
+                var nls LDAPSyntax
+                if err := Marshal(string(ls), &nls, nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
+                        panic(sprintf("%s: %s", err.Error(), string(ls)))
+                }
+                lsc.Set(&nls)
+        }
+}
+
 /////////////////
 // Matching Rules
 
 /*
 PopulateDefaultMatchingRules returns a new auto-populated instance of MatchingRules. Within this structure are all of the following:
 
+• Matching rules from RFC2307 (imported from go-schemax/rfc2307)
+
 • Matching rules from RFC4517 (imported from go-schemax/rfc4517)
 
 • Matching rules from RFC4523 (imported from go-schemax/rfc4523)
+
+• Matching rules from RFC4530 (imported from go-schemax/rfc4530)
 */
 func PopulateDefaultMatchingRules() (mrc MatchingRuleCollection) {
 	mrc = NewMatchingRules()
 	PopulateRFC2307MatchingRules(DefaultLDAPSyntaxes, mrc)
 	PopulateRFC4517MatchingRules(DefaultLDAPSyntaxes, mrc)
 	PopulateRFC4523MatchingRules(DefaultLDAPSyntaxes, mrc)
+	PopulateRFC4530MatchingRules(DefaultLDAPSyntaxes, mrc)
 
 	return
 }
@@ -135,6 +159,23 @@ func PopulateRFC4517MatchingRules(lsc LDAPSyntaxCollection, mrc MatchingRuleColl
 		}
 		mrc.Set(&nmr)
 	}
+}
+
+/*
+PopulateRFC4530MatchingRules only populates the provided MatchingRules (mrc) with MatchingRule definitions defined in this RFC.
+
+Definitions are imported from go-schemax/rfc4530.
+
+A valid instance of LDAPSyntaxes that contains all referenced LDAPSyntax instances must be provided as the lsc argument.
+*/
+func PopulateRFC4530MatchingRules(lsc LDAPSyntaxCollection, mrc MatchingRuleCollection) {
+        for _, mr := range rfc4530.AllMatchingRules {
+                var nmr MatchingRule
+                if err := Marshal(string(mr), &nmr, nil, nil, lsc, mrc, nil, nil, nil, nil); err != nil {
+                        panic(sprintf("%s: %s", err.Error(), string(mr)))
+                }
+                mrc.Set(&nmr)
+        }
 }
 
 /*
@@ -418,6 +459,8 @@ PopulateDefaultAttributeTypes returns a new auto-populated instance of Attribute
 
 • Attribute types from RFC4524 (imported from go-schemax/rfc4524)
 
+• Attribute types from RFC4530 (imported from go-schemax/rfc4530)
+
 • Attribute types from RFC3672 (imported from go-schemax/rfc3672)
 */
 func PopulateDefaultAttributeTypes() (atc AttributeTypeCollection) {
@@ -432,6 +475,10 @@ func PopulateDefaultAttributeTypes() (atc AttributeTypeCollection) {
 		DefaultMatchingRules)
 
 	PopulateRFC4524AttributeTypes(atc,
+		DefaultLDAPSyntaxes,
+		DefaultMatchingRules)
+
+	PopulateRFC4530AttributeTypes(atc,
 		DefaultLDAPSyntaxes,
 		DefaultMatchingRules)
 
@@ -624,6 +671,27 @@ func PopulateRFC4523AttributeTypes(
 		}
 		atc.Set(&nat)
 	}
+}
+
+/*
+PopulateRFC4530AttributeTypes only populates the provided AttributeTypes (atc) with AttributeType definitions defined in this RFC.
+
+Definitions are imported from go-schemax/rfc4530.
+
+Valid instances of LDAPSyntaxes (containing all referenced LDAPSyntax definitions) and MatchingRules (containing all referenced MatchingRules definitions), must be provided as the lsc and mrc arguments respectively.
+*/
+func PopulateRFC4530AttributeTypes(
+        atc AttributeTypeCollection,
+        lsc LDAPSyntaxCollection,
+        mrc MatchingRuleCollection) {
+
+        for _, at := range rfc4530.AllAttributeTypes {
+                var nat AttributeType
+                if err := Marshal(string(at), &nat, atc, nil, lsc, mrc, nil, nil, nil, nil); err != nil {
+                        panic(sprintf("%s: %s", err.Error(), string(at)))
+                }
+                atc.Set(&nat)
+        }
 }
 
 func init() {

--- a/marshal.go
+++ b/marshal.go
@@ -205,23 +205,6 @@ func Marshal(raw string, x interface{},
 }
 
 /*
-DefinitionUnmarshalFunc is a first-class "closure" function intended for use in situations where it is desirable to format a given definition during the unmarshal process, i.e.: to add indents and linebreaks.
-
-The string input argument defines a specifier to be printed just before the definition value. This is used to declare the type of definition being defined in a schema, e.g.: "attributetype". This is particularly useful when interacting with different LDAP DSA products, as such specifiers do vary between implementations.  One real-world example of this is the difference between OpenLDAP and Netscape directory subschema subentries -- namely "attributetype" vs. "attributetypes:". Providing a zero length string argument results in no specifier being printed. The user-provided specifier case is preserved when used (neither "folding" nor normalization will occur).
-
-During the unmarshaling or unsafe stringifaction processes, users may choose to:
-
-• Perform NO formatting whatsoever, producing definitions that span only a single line, or ...
-
-• Use the package-provided formatting closure function appropriate for the definition type, or ...
-
-• Define a custom unmarshal function that honors the defined signature of this type
-
-By default, NO special formatting is performed during unmarshaling or unsafe stringification of definitions.
-*/
-type DefinitionUnmarshalFunc func() (string, error)
-
-/*
 Unmarshal takes an instance of one (1) of the following types and (if valid) and returns the textual form of the definition:
 
 • ObjectClass
@@ -242,24 +225,84 @@ Unmarshal takes an instance of one (1) of the following types and (if valid) and
 
 Should any validation errors occur, a non-nil instance of error is returned.
 */
-func Unmarshal(x interface{}) (def string, err error) {
+func Unmarshal(x interface{}) (string, error) {
+	var err error
+	var defs string
 	switch tv := x.(type) {
-	case *ObjectClass:
-		def, err = tv.unmarshal()
-	case *AttributeType:
-		def, err = tv.unmarshal()
-	case *LDAPSyntax:
-		def, err = tv.unmarshal()
-	case *MatchingRule:
-		def, err = tv.unmarshal()
-	case *MatchingRuleUse:
-		def, err = tv.unmarshal()
-	case *DITContentRule:
-		def, err = tv.unmarshal()
-	case *DITStructureRule:
-		def, err = tv.unmarshal()
-	case *NameForm:
-		def, err = tv.unmarshal()
+	case AttributeTypeCollection:
+		for i := 0; i < tv.Len(); i++ {
+			var def string
+                        if def, err = tv.Index(i).unmarshal(); err != nil {
+				return ``, err
+			}
+			defs += def + "\n\n"
+		}
+		return defs, nil
+        case ObjectClassCollection:
+                for i := 0; i < tv.Len(); i++ {
+                        var def string
+                        if def, err = tv.Index(i).unmarshal(); err != nil {
+                                return ``, err
+                        }
+                        defs += def + "\n\n"
+                }
+                return defs, nil
+        case LDAPSyntaxCollection:
+                for i := 0; i < tv.Len(); i++ {
+                        var def string
+                        if def, err = tv.Index(i).unmarshal(); err != nil {
+                                return ``, err
+                        }
+                        defs += def + "\n\n"
+                }
+                return defs, nil
+        case MatchingRuleCollection:
+                for i := 0; i < tv.Len(); i++ {
+                        var def string
+                        if def, err = tv.Index(i).unmarshal(); err != nil {
+                                return ``, err
+                        }
+                        defs += def + "\n\n"
+                }
+                return defs, nil
+        case MatchingRuleUseCollection:
+                for i := 0; i < tv.Len(); i++ {
+                        var def string
+                        if def, err = tv.Index(i).unmarshal(); err != nil {
+                                return ``, err
+                        }
+                        defs += def + "\n\n"
+                }
+                return defs, nil
+        case DITContentRuleCollection:
+                for i := 0; i < tv.Len(); i++ {
+                        var def string
+                        if def, err = tv.Index(i).unmarshal(); err != nil {
+                                return ``, err
+                        }
+                        defs += def + "\n\n"
+                }
+                return defs, nil
+        case NameFormCollection:
+                for i := 0; i < tv.Len(); i++ {
+                        var def string
+                        if def, err = tv.Index(i).unmarshal(); err != nil {
+                                return ``, err
+                        }
+                        defs += def + "\n\n"
+                }
+                return defs, nil
+        case DITStructureRuleCollection:
+                for i := 0; i < tv.Len(); i++ {
+                        var def string
+                        if def, err = tv.Index(i).unmarshal(); err != nil {
+                                return ``, err
+                        }
+                        defs += def + "\n\n"
+                }
+                return defs, nil
+	case Definition:
+		return tv.unmarshal()
 	default:
 		err = raise(invalidUnmarshal,
 			"unknown or unsupported type %T", tv)
@@ -267,10 +310,10 @@ func Unmarshal(x interface{}) (def string, err error) {
 
 	if err != nil {
 		err = raise(invalidUnmarshal, err.Error())
-	} else if len(def) == 0 {
+	} else {
 		err = raise(invalidUnmarshal,
-			"zero-length definition returned from Unmarshal (of %T)", x)
+			"an unknown error occurred during unmarshal of %T", x)
 	}
 
-	return
+	return ``, err
 }

--- a/mr.go
+++ b/mr.go
@@ -6,10 +6,6 @@ import "sync"
 MatchingRuleCollection describes all MatchingRules-based types.
 */
 type MatchingRuleCollection interface {
-	// Contains returns the index number and presence boolean that
-	// reflects the result of a term search within the receiver.
-	Contains(interface{}) (int, bool)
-
 	// Get returns the *MatchingRule instance retrieved as a result
 	// of a term search, based on Name or OID. If no match is found,
 	// nil is returned.
@@ -27,21 +23,38 @@ type MatchingRuleCollection interface {
 	// the provided *MatchingRule instance to the receiver.
 	Set(*MatchingRule) error
 
-	// String returns a properly-delimited sequence of string
-	// values, either as a Name or OID, for the receiver type.
-	String() string
+        // Contains returns the index number and presence boolean that
+        // reflects the result of a term search within the receiver.
+        Contains(interface{}) (int, bool)
 
-	// Label returns the field name associated with the interface
-	// types, or a zero string if no label is appropriate.
-	Label() string
+        // String returns a properly-delimited sequence of string
+        // values, either as a Name or OID, for the receiver type.
+        String() string
 
-	// IsZero returns a boolean value indicative of whether the
-	// receiver is considered zero, or undefined.
-	IsZero() bool
+        // Label returns the field name associated with the interface
+        // types, or a zero string if no label is appropriate.
+        Label() string
 
-	// Len returns an integer value indicative of the current
-	// number of elements stored within the receiver.
-	Len() int
+        // IsZero returns a boolean value indicative of whether the
+        // receiver is considered zero, or undefined.
+        IsZero() bool
+
+        // Len returns an integer value indicative of the current
+        // number of elements stored within the receiver.
+        Len() int
+
+        // SetSpecifier assigns a string value to all definitions within
+        // the receiver. This value is used in cases where a definition
+        // type name (e.g.: attributetype, objectclass, etc.) is required.
+        // This value will be displayed at the beginning of the definition
+        // value during the unmarshal or unsafe stringification process.
+        SetSpecifier(string)
+
+        // SetUnmarshaler assigns the provided DefinitionUnmarshaler
+        // signature to all definitions within the receiver. The provided
+        // function shall be executed during the unmarshal or unsafe
+        // stringification process.
+        SetUnmarshaler(DefinitionUnmarshaler)
 }
 
 /*
@@ -54,7 +67,7 @@ type MatchingRule struct {
 	Syntax      *LDAPSyntax
 	Extensions  Extensions
 	flags       definitionFlags
-	ufn         DefinitionUnmarshalFunc
+	ufn         DefinitionUnmarshaler
 	spec        string
 	info        []byte
 }
@@ -159,6 +172,24 @@ func (r *MatchingRules) SetMacros(macros *Macros) {
 }
 
 /*
+SetSpecifier is a convenience method that executes the SetSpecifier method in iterative fashion for all definitions within the receiver.
+*/
+func (r *MatchingRules) SetSpecifier(spec string) {
+        for i := 0; i < r.Len(); i++ {
+                r.Index(i).SetSpecifier(spec)
+        }
+}
+
+/*
+SetUnmarshaler is a convenience method that executes the SetUnmarshaler method in iterative fashion for all definitions within the receiver.
+*/
+func (r *MatchingRules) SetUnmarshaler(fn DefinitionUnmarshaler) {
+        for i := 0; i < r.Len(); i++ {
+                r.Index(i).SetUnmarshaler(fn)
+        }
+}
+
+/*
 Contains is a thread-safe method that returns a collection slice element index integer and a presence-indicative boolean value based on a term search conducted within the receiver.
 */
 func (r MatchingRules) Contains(x interface{}) (int, bool) {
@@ -207,7 +238,7 @@ func (r MatchingRules) Len() int {
 }
 
 /*
-String is a stringer method used to return the properly-delimited and formatted series of attributeType name or OID definitions.
+String is a non-functional stringer method needed to satisfy interface type requirements and should not be used. There is no practical application for a list of matchingRule names or object identifiers in this package.
 */
 func (r MatchingRules) String() string { return `` }
 
@@ -269,9 +300,9 @@ func (r *MatchingRule) Info() []byte {
 }
 
 /*
-SetUnmarshalFunc assigns the provided DefinitionUnmarshalFunc signature value to the receiver. The provided function shall be executed during the unmarshal or unsafe stringification process.
+SetUnmarshaler assigns the provided DefinitionUnmarshaler signature value to the receiver. The provided function shall be executed during the unmarshal or unsafe stringification process.
 */
-func (r *MatchingRule) SetUnmarshalFunc(fn DefinitionUnmarshalFunc) {
+func (r *MatchingRule) SetUnmarshaler(fn DefinitionUnmarshaler) {
 	r.ufn = fn
 }
 
@@ -351,7 +382,7 @@ func (r *MatchingRule) unmarshal() (string, error) {
 	}
 
 	if r.ufn != nil {
-		return r.ufn()
+		return r.ufn(r)
 	}
 	return r.unmarshalBasic()
 }
@@ -402,11 +433,25 @@ func (r *MatchingRule) Map() (def map[string][]string) {
 }
 
 /*
-UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+MatchingRuleUnmarshaler is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshaler type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *MatchingRule) UnmarshalFunc() (def string, err error) {
+func MatchingRuleUnmarshaler(x interface{}) (def string, err error) {
+        var r *MatchingRule
+        switch tv := x.(type) {
+        case *MatchingRule:
+                if tv.IsZero() {
+                        err = raise(isZero, "%T is nil", tv)
+                        return
+                }
+                r = tv
+        default:
+                err = raise(unexpectedType,
+                        "Bad type for unmarshal (%T)", tv)
+                return
+        }
+
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/nf.go
+++ b/nf.go
@@ -6,11 +6,7 @@ import "sync"
 NameFormCollection describes all NameForms-based types.
 */
 type NameFormCollection interface {
-	// Contains returns the index number and presence boolean that
-	// reflects the result of a term search within the receiver.
-	Contains(interface{}) (int, bool)
-
-	// // Get returns the *NameForm instance retrieved as a result
+	// Get returns the *NameForm instance retrieved as a result
 	// of a term search, based on Name or OID. If no match is found,
 	// nil is returned.
 	Get(interface{}) *NameForm
@@ -27,21 +23,38 @@ type NameFormCollection interface {
 	// the provided *NameForm instance to the receiver.
 	Set(*NameForm) error
 
-	// String returns a properly-delimited sequence of string
-	// values, either as a Name or OID, for the receiver type.
-	String() string
+        // Contains returns the index number and presence boolean that
+        // reflects the result of a term search within the receiver.
+        Contains(interface{}) (int, bool)
 
-	// Label returns the field name associated with the interface
-	// types, or a zero string if no label is appropriate.
-	Label() string
+        // String returns a properly-delimited sequence of string
+        // values, either as a Name or OID, for the receiver type.
+        String() string
 
-	// IsZero returns a boolean value indicative of whether the
-	// receiver is considered zero, or undefined.
-	IsZero() bool
+        // Label returns the field name associated with the interface
+        // types, or a zero string if no label is appropriate.
+        Label() string
 
-	// Len returns an integer value indicative of the current
-	// number of elements stored within the receiver.
-	Len() int
+        // IsZero returns a boolean value indicative of whether the
+        // receiver is considered zero, or undefined.
+        IsZero() bool
+
+        // Len returns an integer value indicative of the current
+        // number of elements stored within the receiver.
+        Len() int
+
+        // SetSpecifier assigns a string value to all definitions within
+        // the receiver. This value is used in cases where a definition
+        // type name (e.g.: attributetype, objectclass, etc.) is required.
+        // This value will be displayed at the beginning of the definition
+        // value during the unmarshal or unsafe stringification process.
+        SetSpecifier(string)
+
+        // SetUnmarshaler assigns the provided DefinitionUnmarshaler
+        // signature to all definitions within the receiver. The provided
+        // function shall be executed during the unmarshal or unsafe
+        // stringification process.
+        SetUnmarshaler(DefinitionUnmarshaler)
 }
 
 /*
@@ -56,7 +69,7 @@ type NameForm struct {
 	May         AttributeTypeCollection
 	Extensions  Extensions
 	flags       definitionFlags
-	ufn         DefinitionUnmarshalFunc
+	ufn         DefinitionUnmarshaler
 	spec        string
 	info        []byte
 }
@@ -92,6 +105,24 @@ func (r *NameForms) SetMacros(macros *Macros) {
 }
 
 /*
+SetSpecifier is a convenience method that executes the SetSpecifier method in iterative fashion for all definitions within the receiver.
+*/
+func (r *NameForms) SetSpecifier(spec string) {
+        for i := 0; i < r.Len(); i++ {
+                r.Index(i).SetSpecifier(spec)
+        }
+}
+
+/*
+SetUnmarshaler is a convenience method that executes the SetUnmarshaler method in iterative fashion for all definitions within the receiver.
+*/
+func (r *NameForms) SetUnmarshaler(fn DefinitionUnmarshaler) {
+        for i := 0; i < r.Len(); i++ {
+                r.Index(i).SetUnmarshaler(fn)
+        }
+}
+
+/*
 SetInfo assigns the byte slice to the receiver. This is a user-leveraged field intended to allow arbitrary information (documentation?) to be assigned to the definition.
 */
 func (r *NameForm) SetInfo(info []byte) {
@@ -106,9 +137,9 @@ func (r *NameForm) Info() []byte {
 }
 
 /*
-SetUnmarshalFunc assigns the provided DefinitionUnmarshalFunc signature value to the receiver. The provided function shall be executed during the unmarshal or unsafe stringification process.
+SetUnmarshaler assigns the provided DefinitionUnmarshaler signature value to the receiver. The provided function shall be executed during the unmarshal or unsafe stringification process.
 */
-func (r *NameForm) SetUnmarshalFunc(fn DefinitionUnmarshalFunc) {
+func (r *NameForm) SetUnmarshaler(fn DefinitionUnmarshaler) {
 	r.ufn = fn
 }
 
@@ -161,7 +192,7 @@ func (r NameForms) Len() int {
 }
 
 /*
-String is a stringer method used to return the properly-delimited and formatted series of attributeType name or OID definitions.
+String is a non-functional stringer method needed to satisfy interface type requirements and should not be used. There is no practical application for a list of nameForm names or object identifiers in this package.
 */
 func (r NameForms) String() string { return `` }
 
@@ -332,7 +363,7 @@ func (r *NameForm) unmarshal() (string, error) {
 	}
 
 	if r.ufn != nil {
-		return r.ufn()
+		return r.ufn(r)
 	}
 	return r.unmarshalBasic()
 }
@@ -407,11 +438,25 @@ func (r *NameForm) Map() (def map[string][]string) {
 }
 
 /*
-UnmarshalFunc is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshalFunc type.
+NameFormUnmarshaler is a package-included function that honors the signature of the first class (closure) DefinitionUnmarshaler type.
 
 The purpose of this function, and similar user-devised ones, is to unmarshal a definition with specific formatting included, such as linebreaks, leading specifier declarations and indenting.
 */
-func (r *NameForm) UnmarshalFunc() (def string, err error) {
+func NameFormUnmarshaler(x interface{}) (def string, err error) {
+        var r *NameForm
+        switch tv := x.(type) {
+        case *NameForm:
+                if tv.IsZero() {
+                        err = raise(isZero, "%T is nil", tv)
+                        return
+                }
+                r = tv
+        default:
+                err = raise(unexpectedType,
+                        "Bad type for unmarshal (%T)", tv)
+                return
+        }
+
 	var (
 		WHSP string = ` `
 		idnt string = "\n\t"

--- a/rfc4530/at.go
+++ b/rfc4530/at.go
@@ -1,0 +1,21 @@
+package rfc4530
+
+type RFC4530AttributeTypes []RFC4530AttributeType
+type RFC4530AttributeType string
+
+var (
+	AllAttributeTypes RFC4530AttributeTypes
+)
+
+var (
+	EntryUUID		  RFC4530AttributeType
+)
+
+func init() {
+
+	EntryUUID = RFC4530AttributeType(`( 1.3.6.1.1.16.4 NAME 'entryUUID' DESC 'UUID of the entry' EQUALITY uuidMatch ORDERING uuidOrderingMatch SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation X-ORIGIN 'RFC4530' )`)
+
+	AllAttributeTypes = RFC4530AttributeTypes{
+		EntryUUID,
+	}
+}

--- a/rfc4530/ls.go
+++ b/rfc4530/ls.go
@@ -1,0 +1,29 @@
+package rfc4530
+
+/*
+RFC4530LDAPSyntaxes is a slice type designed to store RFC4530LDAPSyntax instances.
+*/
+type RFC4530LDAPSyntaxes []RFC4530LDAPSyntax
+
+/*
+RFC4530Syntax is a struct type that stores the raw RFC4530 syntax definition, along with a boolean value indicative of whether the syntax is considered human-readable.
+*/
+type RFC4530LDAPSyntax string
+
+/*
+LDAPSyntaxes contains slices of all instances of RFC4530LDAPSyntax defined in this package.
+*/
+var AllLDAPSyntaxes RFC4530LDAPSyntaxes
+
+var (
+	UUID			      RFC4530LDAPSyntax
+)
+
+func init() {
+
+	UUID = RFC4530LDAPSyntax(`( 1.3.6.1.1.16.1 DESC 'UUID' X-ORIGIN 'RFC4530' )`)
+
+	AllLDAPSyntaxes = RFC4530LDAPSyntaxes{
+		UUID,
+	}
+}

--- a/rfc4530/mr.go
+++ b/rfc4530/mr.go
@@ -1,0 +1,32 @@
+package rfc4530
+
+/*
+RFC4530MatchingRules is a slice type designed to store instances of RFC4530MatchingRule.
+*/
+type RFC4530MatchingRules []RFC4530MatchingRule
+
+/*
+RFC4530MatchingRule is a string type designed to store a raw MatchingRule definition.
+*/
+type RFC4530MatchingRule string
+
+/*
+MatchingRules contains slices of all instances of RFC4530MatchingRule defined in this package.
+*/
+var AllMatchingRules RFC4530MatchingRules
+
+var (
+	UUIDMatch,
+	UUIDOrderingMatch	  RFC4530MatchingRule
+)
+
+func init() {
+
+	UUIDMatch = RFC4530MatchingRule(`( 1.3.6.1.1.16.2 NAME 'uuidMatch' SYNTAX 1.3.6.1.1.16.1 X-ORIGIN 'RFC4530' )`)
+	UUIDOrderingMatch = RFC4530MatchingRule(`( 1.3.6.1.1.16.3 NAME 'uuidOrderingMatch' SYNTAX 1.3.6.1.1.16.1 X-ORIGIN 'RFC4530' )`)
+
+	AllMatchingRules = []RFC4530MatchingRule{
+		UUIDMatch,
+		UUIDOrderingMatch,
+	}
+}

--- a/rfc4530/rfc4530.txt
+++ b/rfc4530/rfc4530.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                                        K. Zeilenga
+Request for Comments: 4530                           OpenLDAP Foundation
+Category: Standards Track                                      June 2006
+
+
+              Lightweight Directory Access Protocol (LDAP)
+                    entryUUID Operational Attribute
+
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This document describes the LDAP/X.500 'entryUUID' operational
+   attribute and associated matching rules and syntax.  The attribute
+   holds a server-assigned Universally Unique Identifier (UUID) for the
+   object.  Directory clients may use this attribute to distinguish
+   objects identified by a distinguished name or to locate an object
+   after renaming.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zeilenga                    Standards Track                     [Page 1]
+
+RFC 4530                     LDAP entryUUID                    June 2006
+
+
+Table of Contents
+
+   1. Background and Intended Use .....................................2
+   2. UUID Schema Elements ............................................3
+      2.1. UUID Syntax ................................................3
+      2.2. 'uuidMatch' Matching Rule ..................................3
+      2.3. 'uuidOrderingMatch' Matching Rule ..........................3
+      2.4. 'entryUUID' Attribute ......................................4
+   3. Security Considerations .........................................4
+   4. IANA Considerations .............................................5
+      4.1. Object Identifier Registration .............................5
+      4.2. UUID Syntax Registration ...................................5
+      4.3. 'uuidMatch' Descriptor Registration ........................5
+      4.4. 'uuidOrderingMatch' Descriptor Registration ................5
+      4.5. 'entryUUID' Descriptor Registration ........................6
+   5. Acknowledgements ................................................6
+   6. References ......................................................6
+      6.1. Normative References .......................................6
+      6.2. Informative References .....................................7
+
+1.  Background and Intended Use
+
+   In X.500 Directory Services [X.501], such as those accessible using
+   the Lightweight Directory Access Protocol (LDAP) [RFC4510], an object
+   is identified by its distinguished name (DN).  However, DNs are not
+   stable identifiers.  That is, a new object may be identified by a DN
+   that previously identified another (now renamed or deleted) object.
+
+   A Universally Unique Identifier (UUID) is "an identifier unique
+   across both space and time, with respect to the space of all UUIDs"
+   [RFC4122].  UUIDs are used in a wide range of systems.
+
+   This document describes the 'entryUUID' operational attribute, which
+   holds the UUID assigned to the object by the server.  Clients may use
+   this attribute to distinguish objects identified by a particular
+   distinguished name or to locate a particular object after renaming.
+
+   This document defines the UUID syntax, the 'uuidMatch' and
+   'uuidOrderingMatch' matching rules, and the 'entryUUID' attribute
+   type.
+
+   Schema definitions are provided using LDAP description formats
+   [RFC4512].  Definitions provided here are formatted (line wrapped)
+   for readability.
+
+
+
+
+
+
+
+Zeilenga                    Standards Track                     [Page 2]
+
+RFC 4530                     LDAP entryUUID                    June 2006
+
+
+   In this document, the key words "MUST", "MUST NOT", "REQUIRED",
+   "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
+   and "OPTIONAL" are to be interpreted as described in BCP 14
+   [RFC2119].
+
+2.  UUID Schema Elements
+
+2.1.  UUID Syntax
+
+   A Universally Unique Identifier (UUID) [RFC4122] is a 16-octet (128-
+   bit) value that identifies an object.  The ASN.1 [X.680] type UUID is
+   defined to represent UUIDs as follows:
+
+       UUID ::= OCTET STRING (SIZE(16))
+             -- constrained to an UUID [RFC4122]
+
+   In LDAP, UUID values are encoded using the [ASCII] character string
+   representation described in [RFC4122].  For example,
+   "597ae2f6-16a6-1027-98f4-d28b5365dc14".
+
+   The following is an LDAP syntax description suitable for publication
+   in subschema subentries.
+
+       ( 1.3.6.1.1.16.1 DESC 'UUID' )
+
+2.2.  'uuidMatch' Matching Rule
+
+   The 'uuidMatch' matching rule compares an asserted UUID with a stored
+   UUID for equality.  Its semantics are the same as the
+   'octetStringMatch' [X.520][RFC4517] matching rule.  The rule differs
+   from 'octetStringMatch' in that the assertion value is encoded using
+   the UUID string representation instead of the normal OCTET STRING
+   string representation.
+
+   The following is an LDAP matching rule description suitable for
+   publication in subschema subentries.
+
+       ( 1.3.6.1.1.16.2 NAME 'uuidMatch'
+           SYNTAX 1.3.6.1.1.16.1 )
+
+2.3.  'uuidOrderingMatch' Matching Rule
+
+   The 'uuidOrderingMatch' matching rule compares an asserted UUID with
+   a stored UUID for ordering.  Its semantics are the same as the
+   'octetStringOrderingMatch' [X.520][RFC4517] matching rule.  The rule
+   differs from 'octetStringOrderingMatch' in that the assertion value
+   is encoded using the UUID string representation instead of the normal
+   OCTET STRING string representation.
+
+
+
+Zeilenga                    Standards Track                     [Page 3]
+
+RFC 4530                     LDAP entryUUID                    June 2006
+
+
+   The following is an LDAP matching rule description suitable for
+   publication in subschema subentries.
+
+       ( 1.3.6.1.1.16.3 NAME 'uuidOrderingMatch'
+           SYNTAX 1.3.6.1.1.16.1 )
+
+   Note that not all UUID variants have a defined ordering; and even
+   where it does, servers are not obligated to assign UUIDs in any
+   particular order.  This matching rule is provided for completeness.
+
+2.4.  'entryUUID' Attribute
+
+   The 'entryUUID' operational attribute provides the Universally Unique
+   Identifier (UUID) assigned to the entry.
+
+   The following is an LDAP attribute type description suitable for
+   publication in subschema subentries.
+
+       ( 1.3.6.1.1.16.4 NAME 'entryUUID'
+           DESC 'UUID of the entry'
+           EQUALITY uuidMatch
+           ORDERING uuidOrderingMatch
+           SYNTAX 1.3.6.1.1.16.1
+           SINGLE-VALUE
+           NO-USER-MODIFICATION
+           USAGE directoryOperation )
+
+   Servers SHALL generate and assign a new UUID to each entry upon its
+   addition to the directory and provide that UUID as the value of the
+   'entryUUID' operational attribute.  An entry's UUID is immutable.
+
+   UUID are to be generated in accordance with Section 4 of [RFC4122].
+   In particular, servers MUST ensure that each generated UUID is unique
+   in space and time.
+
+3.  Security Considerations
+
+   An entry's relative distinguish name (RDN) is composed from attribute
+   values of the entry, which are commonly descriptive of the object the
+   entry represents.  Although deployers are encouraged to use naming
+   attributes whose values are widely disclosable [RFC4514], entries are
+   often named using information that cannot be disclosed to all
+   parties.  As UUIDs do not contain any descriptive information of the
+   object they identify, UUIDs may be used to identify a particular
+   entry without disclosure of its contents.
+
+   General UUID security considerations [RFC4122] apply.
+
+
+
+
+Zeilenga                    Standards Track                     [Page 4]
+
+RFC 4530                     LDAP entryUUID                    June 2006
+
+
+   General LDAP security considerations [RFC4510] apply.
+
+4.  IANA Considerations
+
+   The IANA has registered the LDAP values [RFC4520] specified in this
+   document.
+
+4.1.  Object Identifier Registration
+
+       Subject: Request for LDAP OID Registration
+       Person & email address to contact for further information:
+           Kurt Zeilenga <kurt@OpenLDAP.org>
+       Specification: RFC 4530
+       Author/Change Controller: IESG
+       Comments:
+           Identifies the UUID schema elements
+
+4.2.  UUID Syntax Registration
+
+       Subject: Request for LDAP Syntax Registration
+       Object Identifier: 1.3.6.1.1.16.1
+       Description: UUID
+       Person & email address to contact for further information:
+           Kurt Zeilenga <kurt@OpenLDAP.org>
+       Specification: RFC 4530
+       Author/Change Controller: IESG
+       Comments:
+            Identifies the UUID syntax
+
+4.3.  'uuidMatch' Descriptor Registration
+
+       Subject: Request for LDAP Descriptor Registration
+       Descriptor (short name): uuidMatch
+       Object Identifier: 1.3.6.1.1.16.2
+       Person & email address to contact for further information:
+           Kurt Zeilenga <kurt@OpenLDAP.org>
+       Usage: Matching Rule
+       Specification: RFC 4530
+       Author/Change Controller: IESG
+
+4.4.  'uuidOrderingMatch' Descriptor Registration
+
+       Subject: Request for LDAP Descriptor Registration
+       Descriptor (short name): uuidOrderingMatch
+       Object Identifier: 1.3.6.1.1.16.3
+       Person & email address to contact for further information:
+           Kurt Zeilenga <kurt@OpenLDAP.org>
+       Usage: Matching Rule
+
+
+
+Zeilenga                    Standards Track                     [Page 5]
+
+RFC 4530                     LDAP entryUUID                    June 2006
+
+
+       Specification: RFC 4530
+       Author/Change Controller: IESG
+
+4.5.  'entryUUID' Descriptor Registration
+
+   The IANA has registered the LDAP 'entryUUID' descriptor.
+
+       Subject: Request for LDAP Descriptor Registration
+       Descriptor (short name): entryUUID
+       Object Identifier: 1.3.6.1.1.16.4
+       Person & email address to contact for further information:
+           Kurt Zeilenga <kurt@OpenLDAP.org>
+       Usage: Attribute Type
+       Specification: RFC 4530
+       Author/Change Controller: IESG
+
+5.  Acknowledgements
+
+   This document is based upon discussions in the LDAP Update and
+   Duplication Protocols (LDUP) WG.  Members of the LDAP Directorate
+   provided review.
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC2119]     Bradner, S., "Key words for use in RFCs to Indicate
+                 Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC4122]     Leach, P., Mealling, M., and R. Salz, "A Universally
+                 Unique IDentifier (UUID) URN Namespace", RFC 4122, July
+                 2005.
+
+   [RFC4510]     Zeilenga, K., Ed., "Lightweight Directory Access
+                 Protocol (LDAP): Technical Specification Road Map", RFC
+                 4510, June 2006.
+
+   [RFC4512]     Zeilenga, K., "Lightweight Directory Access Protocol
+                 (LDAP): Directory Information Models", RFC 4512, June
+                 2006.
+
+   [RFC4517]     Legg, S., Ed., "Lightweight Directory Access Protocol
+                 (LDAP): Syntaxes and Matching Rules", RFC 4517, June
+                 2006.
+
+   [ASCII]       Coded Character Set--7-bit American Standard Code for
+                 Information Interchange, ANSI X3.4-1986.
+
+
+
+
+Zeilenga                    Standards Track                     [Page 6]
+
+RFC 4530                     LDAP entryUUID                    June 2006
+
+
+   [X.501]       International Telecommunication Union -
+                 Telecommunication Standardization Sector, "The
+                 Directory -- Models," X.501(1993) (also ISO/IEC 9594-
+                 2:1994).
+
+   [X.520]       International Telecommunication Union -
+                 Telecommunication Standardization Sector, "The
+                 Directory: Selected Attribute Types", X.520(1993) (also
+                 ISO/IEC 9594-6:1994).
+
+   [X.680]       International Telecommunication Union -
+                 Telecommunication Standardization Sector, "Abstract
+                 Syntax Notation One (ASN.1) - Specification of Basic
+                 Notation", X.680(2002) (also ISO/IEC 8824-1:2002).
+
+6.2.  Informative References
+
+   [RFC4514]     Zeilenga, K., Ed., "Lightweight Directory Access
+                 Protocol (LDAP): String Representation of Distinguished
+                 Names", RFC 4514, June 2006.
+
+   [RFC4520]     Zeilenga, K., "Internet Assigned Numbers Authority
+                 (IANA) Considerations for the Lightweight Directory
+                 Access Protocol (LDAP)", BCP 64, RFC 4520, June 2006.
+
+Author's Address
+
+   Kurt D. Zeilenga
+   OpenLDAP Foundation
+
+   EMail: Kurt@OpenLDAP.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zeilenga                    Standards Track                     [Page 7]
+
+RFC 4530                     LDAP entryUUID                    June 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Zeilenga                    Standards Track                     [Page 8]
+

--- a/subschema.go
+++ b/subschema.go
@@ -102,7 +102,7 @@ func (r *Subschema) set(x interface{}) (ok bool) {
 /*
 PopulateDefaultLDAPSyntaxes is a Subschema-housed convenience method for PopulateDefaultLDAPSyntaxes, and includes internal indexing to maintain proper ordering of definitions.
 */
-func (r *Subschema) PopulateDefaultLDAPSyntaxe() {
+func (r *Subschema) PopulateDefaultLDAPSyntaxes() {
 	r.LSC = PopulateDefaultLDAPSyntaxes()
 }
 

--- a/subschema.go
+++ b/subschema.go
@@ -33,14 +33,14 @@ Overall, use of *Subschema makes generalized use of this package slightly easier
 */
 type Subschema struct {
 	DN   string                     // often "cn=schema" or "cn=subschema", varies per imp.
-	LSC  LDAPSyntaxCollection       // LDAP Syntaxes         OID->*LDAPSyntax
-	MRC  MatchingRuleCollection     // Matching Rules        OID->*MatchingRule
-	ATC  AttributeTypeCollection    // Attribute Types       OID->*AttributeType
-	MRUC MatchingRuleUseCollection  // Matching Rule "Uses"  OID->*MatchingRuleUse
-	OCC  ObjectClassCollection      // Object Classes        OID->*ObjectClass
-	DCRC DITContentRuleCollection   // DIT Content Rules     OID->*DITContentRule
-	NFC  NameFormCollection         // Name Forms            OID->*NameForm
-	DSRC DITStructureRuleCollection // DIT Structure Rules   ID->*DITStructureRule
+	LSC  LDAPSyntaxCollection       // LDAP Syntaxes
+	MRC  MatchingRuleCollection     // Matching Rules
+	ATC  AttributeTypeCollection    // Attribute Types
+	MRUC MatchingRuleUseCollection  // Matching Rule "Uses"
+	OCC  ObjectClassCollection      // Object Classes
+	DCRC DITContentRuleCollection   // DIT Content Rules
+	NFC  NameFormCollection         // Name Forms
+	DSRC DITStructureRuleCollection // DIT Structure Rules
 }
 
 /*


### PR DESCRIPTION
## v0.0.8-alpha

 - Support for RFC4530 added
 - New `_examples` demo file added for file-based schema parsing
 - Decoupled package-provided Unmarshaler functions from associated receiver
 - Documentation fixes
 - `Unmarshal()` now accepts individual definitions AND entire collections
 - `SetSpecifier()` and `SetUnmarshaler()` methods now exist for collection instances