### PR TITLE
v1.1.1

### DIFF
--- a/at.go
+++ b/at.go
@@ -924,9 +924,11 @@ func AttributeTypeUnmarshaler(x interface{}) (def string, err error) {
 		def += WHSP + r.Usage.String()
 	}
 
-	for i := 0; i < r.Extensions.Len(); i++ {
-		if ext := r.Extensions.Index(i); !ext.IsZero() {
-			def += idnt + ext.String()
+	if !r.Extensions.IsZero() {
+		for i := 0; i < r.Extensions.Len(); i++ {
+			if ext := r.Extensions.Index(i); !ext.IsZero() {
+				def += idnt + ext.String()
+			}
 		}
 	}
 

--- a/at.go
+++ b/at.go
@@ -284,7 +284,14 @@ func (r *AttributeTypes) Get(x interface{}) *AttributeType {
 /*
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
-func (r *AttributeTypes) Len() int {
+func (r AttributeTypes) Len() int {
+	if &r == nil {
+		return 0
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
 	return r.slice.len()
 }
 

--- a/collection.go
+++ b/collection.go
@@ -5,8 +5,8 @@ type collection []interface{}
 /*
 len returns the length of the receiver as an int.
 */
-func (c *collection) len() int {
-	return len(*c)
+func (r collection) len() int {
+	return len(r)
 }
 
 /*

--- a/dcr.go
+++ b/dcr.go
@@ -188,12 +188,12 @@ func (r DITContentRules) Get(x interface{}) *DITContentRule {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r DITContentRules) Len() int {
-        if &r == nil {
-                return 0
-        }
+	if &r == nil {
+		return 0
+	}
 
-        r.mutex.Lock()
-        defer r.mutex.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	return r.slice.len()
 }
@@ -483,11 +483,9 @@ func (r *DITContentRule) Map() (def map[string][]string) {
 
 	if !r.Extensions.IsZero() {
 		for i := 0; i < r.Extensions.Len(); i++ {
-			ext := r.Extensions.Index(i)
-			if ext.IsZero() {
-				continue
+			if ext := r.Extensions.Index(i); ext.IsZero() {
+				def[ext.Label] = ext.Value
 			}
-			def[ext.Label] = ext.Value
 		}
 	}
 
@@ -565,9 +563,11 @@ func DITContentRuleUnmarshaler(x interface{}) (def string, err error) {
 		def += WHSP + r.Not.String()
 	}
 
-	for i := 0; i < r.Extensions.Len(); i++ {
-		if ext := r.Extensions.Index(i); !ext.IsZero() {
-			def += idnt + ext.String()
+	if !r.Extensions.IsZero() {
+		for i := 0; i < r.Extensions.Len(); i++ {
+			if ext := r.Extensions.Index(i); !ext.IsZero() {
+				def += idnt + ext.String()
+			}
 		}
 	}
 

--- a/dcr.go
+++ b/dcr.go
@@ -188,8 +188,12 @@ func (r DITContentRules) Get(x interface{}) *DITContentRule {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r DITContentRules) Len() int {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
+        if &r == nil {
+                return 0
+        }
+
+        r.mutex.Lock()
+        defer r.mutex.Unlock()
 
 	return r.slice.len()
 }

--- a/def.go
+++ b/def.go
@@ -391,17 +391,24 @@ func (def *definition) setATFlags(label string, x interface{}) (err error) {
 func (def *definition) setExtensions(label string, value []string, idx int) (err error) {
 	z, ok := def.values[idx].Interface().(*Extensions)
 	if !ok {
-		return raise(unknownDefinition,
+		err = raise(unknownDefinition,
 			"setExtensions: unexpected type '%T'",
 			def.values[idx].Interface())
-	} else if z.IsZero() {
+		return
+	}
+
+	if z.IsZero() {
 		z = NewExtensions()
 	}
 
-	z.Set(&Extension{Label: label, Value: value})
+	z.Set(&Extension{
+		Label: label,
+		Value: value,
+	})
+
 	def.values[idx].Set(valueOf(z))
 
-	return nil
+	return
 }
 
 func (def *definition) setUsage(value string, idx int) (err error) {

--- a/dsr.go
+++ b/dsr.go
@@ -180,6 +180,13 @@ func (r DITStructureRules) Get(x interface{}) *DITStructureRule {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r DITStructureRules) Len() int {
+        if &r == nil {
+                return 0
+        }
+
+        r.mutex.Lock()
+        defer r.mutex.Unlock()
+
 	return r.slice.len()
 }
 

--- a/dsr.go
+++ b/dsr.go
@@ -180,12 +180,12 @@ func (r DITStructureRules) Get(x interface{}) *DITStructureRule {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r DITStructureRules) Len() int {
-        if &r == nil {
-                return 0
-        }
+	if &r == nil {
+		return 0
+	}
 
-        r.mutex.Lock()
-        defer r.mutex.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	return r.slice.len()
 }
@@ -471,11 +471,9 @@ func (r *DITStructureRule) Map() (def map[string][]string) {
 
 	if !r.Extensions.IsZero() {
 		for i := 0; i < r.Extensions.Len(); i++ {
-			ext := r.Extensions.Index(i)
-			if ext.IsZero() {
-				continue
+			if ext := r.Extensions.Index(i); !ext.IsZero() {
+				def[ext.Label] = ext.Value
 			}
-			def[ext.Label] = ext.Value
 		}
 	}
 
@@ -542,9 +540,11 @@ func DITStructureRuleUnmarshaler(x interface{}) (def string, err error) {
 		def += WHSP + r.SuperiorRules.String()
 	}
 
-	for i := 0; i < r.Extensions.Len(); i++ {
-		if ext := r.Extensions.Index(i); !ext.IsZero() {
-			def += idnt + ext.String()
+	if !r.Extensions.IsZero() {
+		for i := 0; i < r.Extensions.Len(); i++ {
+			if ext := r.Extensions.Index(i); !ext.IsZero() {
+				def += idnt + ext.String()
+			}
 		}
 	}
 

--- a/ext.go
+++ b/ext.go
@@ -156,7 +156,14 @@ func (r *Extensions) IsZero() bool {
 	return r == nil
 }
 
-func (r *Extensions) Len() int {
+func (r Extensions) Len() int {
+	if &r == nil {
+		return 0
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
 	return r.slice.len()
 }
 
@@ -166,7 +173,7 @@ Set assigns the provided label and value(s) to the receiver instance. The interf
 All subsequent values (strings or slices of strings) are interpreted as values to be assigned to said label.
 */
 func (r *Extensions) Set(x ...interface{}) {
-	var ext *Extension = new(Extension)
+	var ext *Extension
 	switch tv := x[0].(type) {
 	case string:
 		if len(x) < 2 {
@@ -180,6 +187,8 @@ func (r *Extensions) Set(x ...interface{}) {
 			}
 			vals = append(vals, val)
 		}
+
+		ext = new(Extension)
 		ext.Label = tv
 		ext.Value = vals
 	case *Extension:

--- a/ls.go
+++ b/ls.go
@@ -159,12 +159,12 @@ func (r LDAPSyntaxes) Get(x interface{}) *LDAPSyntax {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r LDAPSyntaxes) Len() int {
-        if &r == nil {
-                return 0
-        }
+	if &r == nil {
+		return 0
+	}
 
-        r.mutex.Lock()
-        defer r.mutex.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	return r.slice.len()
 }
@@ -404,9 +404,11 @@ func (r *LDAPSyntax) Map() (def map[string][]string) {
 		def[`DESC`] = []string{r.Description.String()}
 	}
 
-	for i := 0; i < r.Extensions.Len(); i++ {
-		ext := r.Extensions.Index(i)
-		def[ext.Label] = ext.Value
+	if !r.Extensions.IsZero() {
+		for i := 0; i < r.Extensions.Len(); i++ {
+			ext := r.Extensions.Index(i)
+			def[ext.Label] = ext.Value
+		}
 	}
 
 	return def

--- a/ls.go
+++ b/ls.go
@@ -159,8 +159,12 @@ func (r LDAPSyntaxes) Get(x interface{}) *LDAPSyntax {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r LDAPSyntaxes) Len() int {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
+        if &r == nil {
+                return 0
+        }
+
+        r.mutex.Lock()
+        defer r.mutex.Unlock()
 
 	return r.slice.len()
 }

--- a/mr.go
+++ b/mr.go
@@ -232,12 +232,12 @@ func (r MatchingRules) Get(x interface{}) *MatchingRule {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r MatchingRules) Len() int {
-        if &r == nil {
-                return 0
-        }
+	if &r == nil {
+		return 0
+	}
 
-        r.mutex.Lock()
-        defer r.mutex.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	return r.slice.len()
 }
@@ -494,9 +494,11 @@ func MatchingRuleUnmarshaler(x interface{}) (def string, err error) {
 	def += idnt + r.Syntax.Label()
 	def += WHSP + r.Syntax.OID.String()
 
-	for i := 0; i < r.Extensions.Len(); i++ {
-		if ext := r.Extensions.Index(i); !ext.IsZero() {
-			def += idnt + ext.String()
+	if !r.Extensions.IsZero() {
+		for i := 0; i < r.Extensions.Len(); i++ {
+			if ext := r.Extensions.Index(i); !ext.IsZero() {
+				def += idnt + ext.String()
+			}
 		}
 	}
 

--- a/mr.go
+++ b/mr.go
@@ -232,8 +232,12 @@ func (r MatchingRules) Get(x interface{}) *MatchingRule {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r MatchingRules) Len() int {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
+        if &r == nil {
+                return 0
+        }
+
+        r.mutex.Lock()
+        defer r.mutex.Unlock()
 
 	return r.slice.len()
 }

--- a/mru.go
+++ b/mru.go
@@ -153,8 +153,12 @@ func (r MatchingRuleUses) Get(x interface{}) *MatchingRuleUse {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r MatchingRuleUses) Len() int {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
+        if &r == nil {
+                return 0
+        }
+
+        r.mutex.Lock()
+        defer r.mutex.Unlock()
 
 	return r.slice.len()
 }

--- a/mru.go
+++ b/mru.go
@@ -153,12 +153,12 @@ func (r MatchingRuleUses) Get(x interface{}) *MatchingRuleUse {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r MatchingRuleUses) Len() int {
-        if &r == nil {
-                return 0
-        }
+	if &r == nil {
+		return 0
+	}
 
-        r.mutex.Lock()
-        defer r.mutex.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	return r.slice.len()
 }
@@ -527,9 +527,11 @@ func MatchingRuleUseUnmarshaler(x interface{}) (def string, err error) {
 	def += idnt + r.Applies.Label()
 	def += WHSP + r.Applies.String()
 
-	for i := 0; i < r.Extensions.Len(); i++ {
-		if ext := r.Extensions.Index(i); !ext.IsZero() {
-			def += idnt + ext.String()
+	if !r.Extensions.IsZero() {
+		for i := 0; i < r.Extensions.Len(); i++ {
+			if ext := r.Extensions.Index(i); !ext.IsZero() {
+				def += idnt + ext.String()
+			}
 		}
 	}
 

--- a/nf.go
+++ b/nf.go
@@ -185,12 +185,12 @@ func (r NameForms) Get(x interface{}) *NameForm {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r NameForms) Len() int {
-        if &r == nil {
-                return 0
-        }
+	if &r == nil {
+		return 0
+	}
 
-        r.mutex.Lock()
-        defer r.mutex.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	return r.slice.len()
 }
@@ -517,7 +517,11 @@ func NameFormUnmarshaler(x interface{}) (def string, err error) {
 	}
 
 	if !r.Extensions.IsZero() {
-		def += idnt + r.Extensions.String()
+		for i := 0; i < r.Extensions.Len(); i++ {
+                        if ext := r.Extensions.Index(i); !ext.IsZero() {
+                                def += idnt + ext.String()
+                        }
+		}
 	}
 
 	def += WHSP + tail

--- a/nf.go
+++ b/nf.go
@@ -185,8 +185,12 @@ func (r NameForms) Get(x interface{}) *NameForm {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r NameForms) Len() int {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
+        if &r == nil {
+                return 0
+        }
+
+        r.mutex.Lock()
+        defer r.mutex.Unlock()
 
 	return r.slice.len()
 }

--- a/nf.go
+++ b/nf.go
@@ -518,9 +518,9 @@ func NameFormUnmarshaler(x interface{}) (def string, err error) {
 
 	if !r.Extensions.IsZero() {
 		for i := 0; i < r.Extensions.Len(); i++ {
-                        if ext := r.Extensions.Index(i); !ext.IsZero() {
-                                def += idnt + ext.String()
-                        }
+			if ext := r.Extensions.Index(i); !ext.IsZero() {
+				def += idnt + ext.String()
+			}
 		}
 	}
 

--- a/oc.go
+++ b/oc.go
@@ -233,6 +233,13 @@ func (r ObjectClasses) Get(x interface{}) *ObjectClass {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r ObjectClasses) Len() int {
+        if &r == nil {
+                return 0
+        }
+
+        r.mutex.Lock()
+        defer r.mutex.Unlock()
+
 	return r.slice.len()
 }
 

--- a/oc.go
+++ b/oc.go
@@ -233,12 +233,12 @@ func (r ObjectClasses) Get(x interface{}) *ObjectClass {
 Len is a thread-safe method that returns the effective length of the receiver slice collection.
 */
 func (r ObjectClasses) Len() int {
-        if &r == nil {
-                return 0
-        }
+	if &r == nil {
+		return 0
+	}
 
-        r.mutex.Lock()
-        defer r.mutex.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	return r.slice.len()
 }
@@ -665,9 +665,11 @@ func ObjectClassUnmarshaler(x interface{}) (def string, err error) {
 		def += WHSP + r.May.String()
 	}
 
-	for i := 0; i < r.Extensions.Len(); i++ {
-		if ext := r.Extensions.Index(i); !ext.IsZero() {
-			def += idnt + ext.String()
+	if !r.Extensions.IsZero() {
+		for i := 0; i < r.Extensions.Len(); i++ {
+			if ext := r.Extensions.Index(i); !ext.IsZero() {
+				def += idnt + ext.String()
+			}
 		}
 	}
 


### PR DESCRIPTION
## v1.1.1 Changes

* Fixed panic with regards to certain `Map()` methods not checking whether an `*Extensions` instance is `nil`
* Unified `Len()` method structure, removing inconsistencies between definition types
  * This includes use of `sync` `Mutex`, which was previously implemented in an inconsistent fashion within `Len()` methods